### PR TITLE
Update Hugo configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ baseURL: https://falco.org/
 languageCode: en-us
 title: Falco - Container Native Runtime Security
 theme: falco-fresh
-publishDir: ../falcosecurity.github.io
+disableKinds: ["taxonomy", "taxonomyTerm"]
 
 params:
   primaryFont:


### PR DESCRIPTION
This PR updates the Hugo configuration to publish to the default `public` directory (rather than using a separate repo for GitHub Pages) and disables taxonomies (which currently aren't being used by the site).