### PR TITLE
Add md5sum shortcode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ pygmentsCodefences: true
 pygmentsStyle: monokai
 
 params:
+  md5sum: 3632bde02be5aeaef522138919cfece2
   primaryFont:
     name: "Karla"
     sizes: [400 700]

--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -27,7 +27,7 @@ Then verify the [MD5](https://en.wikipedia.org/wiki/MD5) checksum of the script 
 md5sum install-falco.sh
 ```
 
-It should be `3632bde02be5aeaef522138919cfece2`.
+It should be `{{< md5sum >}}`.
 
 Then run the script either as root or with sudo:
 

--- a/themes/falco-fresh/layouts/shortcodes/md5sum.html
+++ b/themes/falco-fresh/layouts/shortcodes/md5sum.html
@@ -1,0 +1,1 @@
+{{- site.Params.md5sum -}}


### PR DESCRIPTION
This PR enables you to set the expected md5sum in the site's configuration rather than needing to hard-code it in Markdown.

The `md5sum` shortcode can also be re-used anywhere in the documentation in the future.

Also, @mfdii, the current checksum seems to be incorrect if I'm not mistaken. Should we update? I'm getting `228e1a9002f5d00dc40fafe13b1bd1ab` from the downloadable script.