### PR TITLE
Provide cheatsheet scaffolding

### DIFF
--- a/content/cheatsheet/forbidden-thing.yaml
+++ b/content/cheatsheet/forbidden-thing.yaml
@@ -1,0 +1,3 @@
+- rule: forbid_something
+  desc: This thing shouldn't happen
+  condition: not thing in (allowed_thing, other_allowed_thing)

--- a/content/cheatsheet/other-thing.yaml
+++ b/content/cheatsheet/other-thing.yaml
@@ -1,0 +1,1 @@
+key: value

--- a/content/docs/cheatsheet.md
+++ b/content/docs/cheatsheet.md
@@ -1,0 +1,6 @@
+---
+title: Falco Cheatsheet
+draft: true
+---
+
+{{< cheatsheet >}}

--- a/data/cheatsheet.yaml
+++ b/data/cheatsheet.yaml
@@ -1,0 +1,4 @@
+forbidden-thing:
+  title: Do a thing
+other-thing:
+  title: Some other thing

--- a/data/cheatsheet.yaml
+++ b/data/cheatsheet.yaml
@@ -1,4 +1,13 @@
-forbidden-thing:
-  title: Do a thing
-other-thing:
-  title: Some other thing
+groups:
+- name: Group 1
+  cheats:
+  - filename: forbidden-thing
+    title: Do a thing
+  - filename: other-thing
+    title: A different thing
+  - filename: other-thing
+    title: A different thing
+- name: Group 2
+  cheats:
+  - filename: other-thing
+    title: Some other thing

--- a/themes/falco-fresh/assets/cheatsheet.sass
+++ b/themes/falco-fresh/assets/cheatsheet.sass
@@ -1,27 +1,32 @@
 .cheatsheet
-  display: flex
+  &-group
+    &-title
+      font-size: 1.75rem
 
-  +desktop
-    flex-flow: row nowrap
-  +mobile
-    flex-flow: column nowrap
+    & + &
+      margin-top: 2rem
 
-  flex-flow: row nowrap
-  justify-content: space-between
+  &-cheats
+    display: flex
+    justify-content: space-between
 
-  .cheat
-    padding: 1rem
-    background-color: $light
+    .cheat
+      padding: 1rem
+      background-color: $light
+
+      &-title
+        font-weight: 700
+        font-size: 1.25rem
 
     +desktop
-      width: calc(50% - .25rem)
+      flex-flow: row wrap
+
+      .cheat
+        margin-bottom: 1rem
+        width: calc(50% - .25rem)
+
     +mobile
-      width: 100%
+      flex-flow: column nowrap
 
-      & + .cheat
+      .cheat + .cheat
         margin-top: 1rem
-
-    &-title
-      font-size: 1.25rem
-      font-weight: 700
-

--- a/themes/falco-fresh/assets/cheatsheet.sass
+++ b/themes/falco-fresh/assets/cheatsheet.sass
@@ -1,0 +1,27 @@
+.cheatsheet
+  display: flex
+
+  +desktop
+    flex-flow: row nowrap
+  +mobile
+    flex-flow: column nowrap
+
+  flex-flow: row nowrap
+  justify-content: space-between
+
+  .cheat
+    padding: 1rem
+    background-color: $light
+
+    +desktop
+      width: calc(50% - .25rem)
+    +mobile
+      width: 100%
+
+      & + .cheat
+        margin-top: 1rem
+
+    &-title
+      font-size: 1.25rem
+      font-weight: 700
+

--- a/themes/falco-fresh/assets/style.sass
+++ b/themes/falco-fresh/assets/style.sass
@@ -27,6 +27,7 @@ $colors: mergeColorMaps(("twitter-blue": ($twitter-blue, $white)), $colors)
 @import "bulma-dashboard/src/bulma-dashboard"
 
 @import "toc"
+@import "cheatsheet"
 
 .is-cncf-logo
   margin-top: 2rem

--- a/themes/falco-fresh/layouts/shortcodes/cheat.html
+++ b/themes/falco-fresh/layouts/shortcodes/cheat.html
@@ -1,0 +1,8 @@
+{{ $key   := .Get 0 }}
+{{ $cheat := index site.Data.cheatsheet $key }}
+{{ $title := $cheat.title }}
+{{ $file  := printf "cheatsheet/%s.yaml" $key }}
+{{ $yaml  := readFile $file }}
+<h2>{{ $title }}</h2>
+
+{{ highlight $yaml "yaml" "" }}

--- a/themes/falco-fresh/layouts/shortcodes/cheatsheet.html
+++ b/themes/falco-fresh/layouts/shortcodes/cheatsheet.html
@@ -1,14 +1,24 @@
-{{ $cheats := site.Data.cheatsheet }}
+{{ $groups := site.Data.cheatsheet.groups }}
 <div class="cheatsheet">
-  {{ range $k, $v := $cheats }}
-  {{ $yaml  := readFile (printf "cheatsheet/%s.yaml" $k) }}
-  {{ $title := $v.title | markdownify }}
-  <div class="cheat">
-    <p class="cheat-title">
-      {{ $title }}
+  {{ range $groups }}
+  <div class="cheatsheet-group">
+    <p class="cheatsheet-group-title">
+      {{ .name }}
     </p>
 
-    {{ highlight $yaml "yaml" "" }}
+    <div class="cheatsheet-cheats">
+      {{ range .cheats }}
+      {{ $yaml  := readFile (printf "cheatsheet/%s.yaml" .filename) }}
+      {{ $title := .title | markdownify }}
+      <div class="cheat">
+        <p class="cheat-title">
+          {{ $title }}
+        </p>
+
+        {{ highlight $yaml "yaml" "" }}
+      </div>
+      {{ end }}
+    </div>
   </div>
   {{ end }}
 </div>

--- a/themes/falco-fresh/layouts/shortcodes/cheatsheet.html
+++ b/themes/falco-fresh/layouts/shortcodes/cheatsheet.html
@@ -1,0 +1,14 @@
+{{ $cheats := site.Data.cheatsheet }}
+<div class="cheatsheet">
+  {{ range $k, $v := $cheats }}
+  {{ $yaml  := readFile (printf "cheatsheet/%s.yaml" $k) }}
+  {{ $title := $v.title | markdownify }}
+  <div class="cheat">
+    <p class="cheat-title">
+      {{ $title }}
+    </p>
+
+    {{ highlight $yaml "yaml" "" }}
+  </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
Addresses issue #42. With these changes, you can add a "cheat" for the cheatsheet by:

1. Adding an entry to `data/cheatsheet.yaml`
1. Adding a YAML file in `docs/cheatsheet` with the example YAML (the filename must correspond to the key in `data/cheatsheet.yaml`)

You can see the very basic example at https://deploy-preview-49--falcosecurity.netlify.com/docs/cheatsheet.

There are a lot of directions this could be taken. The cheats could be divided into groups, etc.