### PR TITLE
Fix home link

### DIFF
--- a/themes/falco-fresh/layouts/partials/navbar.html
+++ b/themes/falco-fresh/layouts/partials/navbar.html
@@ -3,7 +3,7 @@
 {{- $cncf    := index $navbar "cncf" }}
 {{- $isHome  := .IsHome }}
 {{- $isDocs  := eq .Section "docs" }}
-{{- $baseUrl := printf "/%s" .Language }}
+{{- $baseUrl := site.BaseURL }}
 <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
   {{ if $isHome }}<div class="container">{{ end }}
     <div class="navbar-brand">


### PR DESCRIPTION
Someone changed the base URL in the navbar to `/{language}`. That system will not work until we have multiple languages working on the site. For now it 404s.