### PR TITLE
add a shortcode + doc page to display changelog from github releases

### DIFF
--- a/content/en/docs/changelog.md
+++ b/content/en/docs/changelog.md
@@ -1,0 +1,6 @@
+---
+title: "Changelog"
+date: 2019-09-30T20:34:16+02:00
+draft: false
+---
+{{% changelog "https://api.github.com/repos/falcosecurity/falco/releases" %}}

--- a/themes/falco-fresh/layouts/shortcodes/changelog.html
+++ b/themes/falco-fresh/layouts/shortcodes/changelog.html
@@ -1,0 +1,9 @@
+{{ $dataJSONURL := (.Get 0) }}
+{{ $dataJSON := getJSON $dataJSONURL }}
+{{ range $dataJSON }}
+  <div>
+    <div><span style="font-weight: bold; font-size: 250%; color: #00b4c8">{{ .tag_name }}</span></div>
+    <div class="desc" style="padding-left: 5%; padding-top: 1%">{{ .body | markdownify }}</div>
+  </div>
+  <br>
+{{ end }}


### PR DESCRIPTION
**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

This PR provides a new Hugo shortcode for creating a changelog page into /docs section. Each time the website is "built", the shortcode calls github API to gather all releases and generates a full changelog page. No need to update a variable.

![image](https://user-images.githubusercontent.com/4520100/65951466-6381c680-e440-11e9-9376-adf7831de45d.png)

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A