### PR TITLE
latest release tag is auto-gathered

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -154,6 +154,7 @@ languages:
 
 params:
   version: v0.17.1
+  githubRepository : falcosecurity/falco
   sha256sum: ecd5517492ebb356b820f404aea4afcb9d2d81bf98c55a8174b050c5bbc7092a
   primaryFont:
     name: "Karla"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.53"
+HUGO_VERSION = "0.58.3"
 
 [context.deploy-preview]
 command = "make preview-build"

--- a/themes/falco-fresh/layouts/partials/docs/dashboard.html
+++ b/themes/falco-fresh/layouts/partials/docs/dashboard.html
@@ -1,8 +1,10 @@
-{{ $docsSections := where site.Sections "Section" "docs" }}
-{{ $currentUrl   := .RelPermalink }}
-{{ $logo         := "/images/logos/falco-logo.png" | relURL }}
-{{ $home         := site.BaseURL }}
-{{ $version      := site.Params.version }}
+{{ $docsSections     := where site.Sections "Section" "docs" }}
+{{ $currentUrl       := .RelPermalink }}
+{{ $logo             := "/images/logos/falco-logo.png" | relURL }}
+{{ $home             := site.BaseURL }}
+{{ $githubRepository := site.Params.githubRepository }}
+{{ $dataJSON := getJSON "https://api.github.com/repos/" $githubRepository "/releases/latest" }}
+
 <div class="dashboard">
   <div class="dashboard-panel left is-hidden-mobile is-scrollable">
     <div class="dashboard-panel-header has-text-centered">
@@ -13,7 +15,7 @@
       <br /><br />
 
       <div class="button is-primary is-radiusless">
-        Version&nbsp;<strong>{{ $version }}</strong>
+        Version&nbsp;<strong>{{ $dataJSON.tag_name }}</strong>
       </div>
     </div>
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind content

**Any specific area of the project related to this PR?**

> /area documentation

**What this PR does / why we need it**:

Documentation header indicates latest available release, this needed to be manually updated in site parameters. Not it uses github's API to retrieve last release tag and complete header. Only need to rebuild site to be up to date.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A
