### PR TITLE
Use backtick-based highlighting

### DIFF
--- a/content/en/docs/grpc/_index.md
+++ b/content/en/docs/grpc/_index.md
@@ -18,8 +18,7 @@ The Falco gRPC server and the Falco gRPC Outputs APIs are not enabled by default
 
 To enable them, edit the `falco.yaml` Falco configuration file. A sample Falco configuration file is given below:
 
-{{< highlight yaml >}}
-
+```yaml
 # gRPC server configuration.
 # The gRPC server is secure by default (mutual TLS) so you need to generate certificates and update their paths here.
 # By default the gRPC server is off.
@@ -39,8 +38,7 @@ grpc:
 # By enabling this all the output events will be kept in memory until you read them with a gRPC client.
 grpc_output:
   enabled: true
-
-{{< / highlight >}}
+```
 
 
 ### Certificates
@@ -57,47 +55,46 @@ In the meantime, use the following script to generate the certificates.
 
 Run the following command:
 
-{{< highlight bash >}}
+```bash
 $ openssl genrsa -passout pass:1234 -des3 -out ca.key 4096
 $ openssl req -passin pass:1234 -new -x509 -days 365 -key ca.key -out ca.crt -subj  "/C=SP/ST=Italy/L=Ornavasso/O=Test/OU=Test/CN=Root CA"
-{{< / highlight >}}
+```
 
 ### Generate valid Server Key/Cert
 
 Run the following command:
 
-{{< highlight bash >}}
+```bash
 $ openssl genrsa -passout pass:1234 -des3 -out server.key 4096
 $ openssl req -passin pass:1234 -new -key server.key -out server.csr -subj  "/C=SP/ST=Italy/L=Ornavasso/O=Test/OU=Server/CN=localhost"
 $ openssl x509 -req -passin pass:1234 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out server.crt
-{{< / highlight >}}
+```
 
 ### Remove passphrase from the Server Key
 
 Run the following command:
 
-{{< highlight bash >}}
+```bash
 $ openssl rsa -passin pass:1234 -in server.key -out server.key
-{{< / highlight >}}
-
+```
 
 ### Generate valid Client Key/Cert
 
 Run the following command:
 
-{{< highlight bash >}}
+```bash
 $ openssl genrsa -passout pass:1234 -des3 -out client.key 4096
 $ openssl req -passin pass:1234 -new -key client.key -out client.csr -subj  "/C=SP/ST=Italy/L=Ornavasso/O=Test/OU=Client/CN=localhost"
 $ openssl x509 -passin pass:1234 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt
-{{< / highlight >}}
+```
 
 ### Remove passphrase from Client Key
 
 Run the following command:
 
-{{< highlight bash >}}
+```bash
 $ openssl rsa -passin pass:1234 -in client.key -out client.key
-{{< / highlight >}}
+```
 
 ## Usage
 
@@ -105,8 +102,8 @@ When the configuration is complete, Falco is ready to expose its gRPC server and
 
 To do so, simply run Falco. For example:
 
-{{< highlight bash >}}
+```bash
 $ falco -c falco.yaml -r rules/falco_rules.yaml -r rules/falco_rules.local.yaml -r rules/k8s_audit_rules.yaml
-{{< / highlight >}}
+```
 
 Refer to the [Go example](./outputs) to learn how to receive and consume the output events.

--- a/content/en/docs/grpc/client-go.md
+++ b/content/en/docs/grpc/client-go.md
@@ -14,54 +14,54 @@ Refer to the [fully-functional example](https://github.com/falcosecurity/client-
 
 2. From the [client-go](https://github.com/falcosecurity/client-go) root directory, run:
 
-{{< highlight bash >}}
-  $ go run examples/output/main.go | jq
-{{< / highlight >}}
+    ```bash
+    $ go run examples/output/main.go | jq
+    ```
 
-  You should see output events starting flowing in depending on the set of rules
-your Falco instance has.
+    You should see output events starting flowing in depending on the set of rules
+  your Falco instance has.
 
-{{< highlight json >}}
-{
-  "time": {
-    "seconds": 1570094449,
-    "nanos": 259268899
-  },
-  "priority": 3,
-  "rule": "Modify binary dirs",
-  "output": "09:20:49.259268899: Error File below known binary directory renamed/removed (user=vagrant command=lua /home/vagrant/.dotfiles/zsh/.config/zsh/plugins/z.lua/z.lua --init zsh once enhanced pcmdline=zsh operation=rena
-me file=<NA> res=0 oldpath=/usr/bin/realpath newpath=/usr/bin/realpath container_id=host image=<NA>)",
-  "output_fields": {
-    "container.id": "host",
-    "container.image.repository": "<NA>",
-    "evt.args": "res=0 oldpath=/usr/bin/realpath newpath=/usr/bin/realpath ",
-    "evt.time": "09:20:49.259268899",
-    "evt.type": "rename",
-    "fd.name": "<NA>",
-    "proc.cmdline": "lua /home/vagrant/.dotfiles/zsh/.config/zsh/plugins/z.lua/z.lua --init zsh once enhanced",
-    "proc.pcmdline": "zsh",
-    "user.name": "vagrant"
-  }
-}
-{
-  "time": {
-    "seconds": 1570094449,
-    "nanos": 620298462
-  },
-  "priority": 4,
-  "rule": "Delete or rename shell history",
-  "output": "09:20:49.620298462: Warning Shell history had been deleted or renamed (user=vagrant type=unlink command=zsh fd.name=<NA> name=<NA> path=/home/vagrant/.zsh_history.LOCK oldpath=<NA> host (id=host))",
-  "output_fields": {
-    "container.id": "host",
-    "container.name": "host",
-    "evt.arg.name": "<NA>",
-    "evt.arg.oldpath": "<NA>",
-    "evt.arg.path": "/home/vagrant/.zsh_history.LOCK",
-    "evt.time": "09:20:49.620298462",
-    "evt.type": "unlink",
-    "fd.name": "<NA>",
-    "proc.cmdline": "zsh",
-    "user.name": "vagrant"
-  }
-}
-{{< / highlight >}}
+    ```json
+    {
+      "time": {
+        "seconds": 1570094449,
+        "nanos": 259268899
+      },
+      "priority": 3,
+      "rule": "Modify binary dirs",
+      "output": "09:20:49.259268899: Error File below known binary directory renamed/removed (user=vagrant command=lua /home/vagrant/.dotfiles/zsh/.config/zsh/plugins/z.lua/z.lua --init zsh once enhanced pcmdline=zsh operation=rena
+    me file=<NA> res=0 oldpath=/usr/bin/realpath newpath=/usr/bin/realpath container_id=host image=<NA>)",
+      "output_fields": {
+        "container.id": "host",
+        "container.image.repository": "<NA>",
+        "evt.args": "res=0 oldpath=/usr/bin/realpath newpath=/usr/bin/realpath ",
+        "evt.time": "09:20:49.259268899",
+        "evt.type": "rename",
+        "fd.name": "<NA>",
+        "proc.cmdline": "lua /home/vagrant/.dotfiles/zsh/.config/zsh/plugins/z.lua/z.lua --init zsh once enhanced",
+        "proc.pcmdline": "zsh",
+        "user.name": "vagrant"
+      }
+    }
+    {
+      "time": {
+        "seconds": 1570094449,
+        "nanos": 620298462
+      },
+      "priority": 4,
+      "rule": "Delete or rename shell history",
+      "output": "09:20:49.620298462: Warning Shell history had been deleted or renamed (user=vagrant type=unlink command=zsh fd.name=<NA> name=<NA> path=/home/vagrant/.zsh_history.LOCK oldpath=<NA> host (id=host))",
+      "output_fields": {
+        "container.id": "host",
+        "container.name": "host",
+        "evt.arg.name": "<NA>",
+        "evt.arg.oldpath": "<NA>",
+        "evt.arg.path": "/home/vagrant/.zsh_history.LOCK",
+        "evt.time": "09:20:49.620298462",
+        "evt.type": "unlink",
+        "fd.name": "<NA>",
+        "proc.cmdline": "zsh",
+        "user.name": "vagrant"
+      }
+    }
+    ```


### PR DESCRIPTION
There's nothing wrong with using Hugo's `{{< highlight >}}` shortcode for syntax highlighting, and there are even cases where it's necessary, but when you do so you lose (a) text editor compatibility, and (b) highlighting on GitHub.