### PR TITLE
fix: wrong label for viewing logs

### DIFF
--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -95,7 +95,7 @@ kubectl apply -f k8s-with-rbac/falco-daemonset-configmap.yaml
 
 7. Verify Falco started correctly. To do so, check the status of the Falco pods in the corresponding log files.
 ```shell
-kubectl logs -l app=falco
+kubectl logs -l app=falco-example
 ```
 
 ### Minikube


### PR DESCRIPTION
Signed-off-by: James Naftel <james.naftel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind transalation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation


**What this PR does / why we need it**:
I was working through the installation instructions and noticed that the label seems to be wrong for viewing logs through kubectl.

Step 7 under daemonsets.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
