### PR TITLE
Update sha256sum for curl | bash installer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -175,7 +175,7 @@ languages:
 params:
   version: v0.18.0
   githubRepository : falcosecurity/falco
-  sha256sum: ecd5517492ebb356b820f404aea4afcb9d2d81bf98c55a8174b050c5bbc7092a
+  sha256sum: dc480d202e7ebd3596f3a7aa8cd6e29ed5d4d427f927bd868771d9452d6a97b4
   primaryFont:
     name: "Karla"
     sizes: [400 700]


### PR DESCRIPTION
I don't know when these got out of sync. I wasn't able to find the git
repo holding the installer script to verify.


**What type of PR is this?**

/kind cleanup


**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

The sha256sum of the `curl | bash` install script has diverged from the text on the website. This fixes that.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I wasn't able to find the upstream source of the installer script. It would be good to know what changed in the script to cause the sha to change just for peace of mind.