### PR TITLE
Use shortcodes for version insertion

### DIFF
--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -128,7 +128,7 @@ eBPF is currently supported only on GKE and COS, however here we provide install
 When using the official container images, setting this environment variable will trigger the `falco-probe-loader` script to download the kernel headers for the appropriate version of COS, and then compile the appropriate eBPF probe. In all the other environments you can call the `falco-probe-loader` script yourself to obtain it in this way:
 
 ```bash
-sudo FALCO_VERSION="0.20.0" FALCO_BPF_PROBE="" falco-probe-loader 
+sudo FALCO_VERSION="{{< latest >}}" FALCO_BPF_PROBE="" falco-probe-loader
 ```
 
 To execute the script above succesfully, you will need `clang` and `llvm` installed.

--- a/content/en/docs/source.md
+++ b/content/en/docs/source.md
@@ -333,7 +333,7 @@ Notice this variable is case-insensitive and it defaults to release.
 Optionally the user can specify the version he wants Falco to have. Eg.,
 
 ```
- -DFALCO_VERSION=0.20.0-dirty
+ -DFALCO_VERSION={{< latest >}}-dirty
 ```
 
 When not explicitly specifying it the build system will compute the `FALCO_VERSION` value from the git history.


### PR DESCRIPTION
This PR follows up on #147 and uses the `latest` shortcode to dynamically insert the latest version. Make sure to use this method for version insertion in the future for the sake of maintainability.