### PR TITLE
Falco Slack URL updated to CNCF

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ languages:
           text: Join our Slack team to interact with other users and developers.
           icon: chat.png
           buttonText: Falco Slack
-          buttonLink: https://slack.sysdig.com/
+          buttonLink: https://cloud-native.slack.com/archives/falco
       signup:
         title: Join the mailing list
         subtitle: Get involved with the community
@@ -156,7 +156,7 @@ languages:
           text: 加入我们的Slack团队，和其他用户和开发者沟通交流。
           icon: chat.png
           buttonText: Falco Slack
-          buttonLink: https://slack.sysdig.com/
+          buttonLink: https://cloud-native.slack.com/archives/falco
       signup:
         title: 加入CNCF官方邮件列表。
         subtitle: 从这注册
@@ -240,7 +240,7 @@ languages:
           text: Slackチームに参加して、他のユーザーやデベロッパーと交流してください。
           icon: chat.png
           buttonText: Falco Slack
-          buttonLink: https://slack.sysdig.com/
+          buttonLink: https://cloud-native.slack.com/archives/falco
       signup:
         title: メーリングリストに参加する
         subtitle: コミュニティに参加する

--- a/content/en/blog/cloud-native-security-hub.md
+++ b/content/en/blog/cloud-native-security-hub.md
@@ -72,7 +72,7 @@ Keep reading to find out more on how to get involved and contribute, especially 
 
 The project was originally started by Sysdig, but maintaining the repositories, and building out rules will now be governed by the CNCF and the Falco community. 
 
-If you are interested in getting involved with writing rules, or building out tooling around the new hub please reach out to [The official CNCF Falco Mailing List](https://lists.cncf.io/g/cncf-falco-dev) or join the [Falco slack channel](https://slack.sysdig.com).
+If you are interested in getting involved with writing rules, or building out tooling around the new hub please reach out to [The official CNCF Falco Mailing List](https://lists.cncf.io/g/cncf-falco-dev) or join the [Falco slack channel](https://cloud-native.slack.com/archives/falco).
 
 ### Integrating with Falcoctl
 


### PR DESCRIPTION
Falco Slack conversations are moving to the CNCF Slack.

Fixes https://github.com/falcosecurity/falco/issues/983

/kind content
/area blog
/area documentation

Signed-off-by: Ihor Dvoretskyi <ihor@linux.com>