### PR TITLE
update: direct link to the new slack channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,7 +90,7 @@ languages:
         subtitle: Sign up for the development mailing list
         buttonText: Submit
         slackText: Falco Slack Channels
-        slackLink: https://slack.k8s.io/
+        slackLink: https://kubernetes.slack.com/archives/falco
         mailingListText: Developer Mailing List
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
         communityText: Github Community
@@ -190,7 +190,7 @@ languages:
         subtitle: Sign up for the development mailing list
         buttonText: Submit
         slackText: Falco Slack Channels
-        slackLink: https://slack.k8s.io/
+        slackLink: https://kubernetes.slack.com/archives/falco
         mailingListText: Developer Mailing List
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
         communityText: Github Community
@@ -296,7 +296,7 @@ languages:
         subtitle: Sign up for the development mailing list
         buttonText: Submit
         slackText: Falco Slack Channels
-        slackLink: https://slack.k8s.io/
+        slackLink: https://kubernetes.slack.com/archives/falco
         mailingListText: Developer Mailing List
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
         communityText: Github Community

--- a/content/en/blog/cloud-native-security-hub.md
+++ b/content/en/blog/cloud-native-security-hub.md
@@ -72,7 +72,7 @@ Keep reading to find out more on how to get involved and contribute, especially 
 
 The project was originally started by Sysdig, but maintaining the repositories, and building out rules will now be governed by the CNCF and the Falco community. 
 
-If you are interested in getting involved with writing rules, or building out tooling around the new hub please reach out to [The official CNCF Falco Mailing List](https://lists.cncf.io/g/cncf-falco-dev) or join the [Falco slack channel](https://slack.sysdig.com).
+If you are interested in getting involved with writing rules, or building out tooling around the new hub please reach out to [The official CNCF Falco Mailing List](https://lists.cncf.io/g/cncf-falco-dev) or join the [Falco slack channel](https://kubernetes.slack.com/archives/falco).
 
 ### Integrating with Falcoctl
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:


/kind content

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area blog

/area documentation


**What this PR does / why we need it**:

Quoting @leodido who explained the reason very well: 

> After a [very long discussion](https://github.com/falcosecurity/falco/issues/983) with CNCF, we finally decided to move the Slack community over the Kubernetes slack (as per Chris A. 's suggestion [here](https://github.com/falcosecurity/falco/issues/983#issuecomment-625901549)).
> 
> We are going to [officially announce the cutoff](https://github.com/falcosecurity/falco/issues/983#issuecomment-630980624) during today community call! 
> 
> And we already started putting documentation about the new channels (and the new slack) in place for the community (see [here](https://github.com/falcosecurity/community/pull/95/files)).
> 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
The #falco channel on Kubernetes Slack was added [here](https://github.com/kubernetes/community/pull/4038). So we can update it right now.

/cc @kris-nova 
/cc @leodido 
/cc @fntlnz 