### PR TITLE
fix(docs): direct helm chart link

### DIFF
--- a/content/en/docs/third-party.md
+++ b/content/en/docs/third-party.md
@@ -65,7 +65,8 @@ kind create cluster --config=./kind-config.yaml
 
 ## Helm
 
-Helm is a way to install Falco in Kubernetes. The Falco community supports a helm chart and documentation on how to use it can [be found here](https://github.com/falcosecurity/charts).
+Helm is a way to install Falco in Kubernetes. The Falco community supports a helm chart and documentation on how to use it can [be found here](https://github.com/falcosecurity/charts/tree/master/falco).
+
 ## Puppet
 
 A [Puppet](https://puppet.com/) module for Falco, `sysdig-falco`, is available on [Puppet Forge](https://forge.puppet.com/sysdig/falco/readme).


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation


**What this PR does / why we need it**:

Change the Helm chart link to point to the Falco's chart directly.
It will help folks to find instruction easily. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
https://kubernetes.slack.com/archives/CMWH3EH32/p1591372966173800?thread_ts=1591369299.170300&cid=CMWH3EH32

/cc @kris-nova 