### PR TITLE
update(content/en/docs/running): add `SKIP_DRIVER_LOADER` option

### DIFF
--- a/content/en/docs/running.md
+++ b/content/en/docs/running.md
@@ -147,6 +147,7 @@ docker run --rm -i -t \
 
 Other configurable options:
 
+- `DRIVER_REPO` - See the [Installing the driver](https://falco.org/docs/installation/#install-driver) section.
 - `SKIP_DRIVER_LOADER` - Set this environment variable to avoid running `falco-driver-loader` when the `falcosecurity/falco` image starts. Useful when the driver has been already installed on the host by other means.
 
 ## Hot Reload

--- a/content/en/docs/running.md
+++ b/content/en/docs/running.md
@@ -145,6 +145,9 @@ docker run --rm -i -t \
     falcosecurity/falco:latest
 ```
 
+Other configurable options:
+
+- `SKIP_DRIVER_LOADER` - Set this environment variable to avoid running `falco-driver-loader` when the `falcosecurity/falco` image starts. Useful when the driver has been already installed on the host by other means.
 
 ## Hot Reload
 


### PR DESCRIPTION
**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation


**What this PR does / why we need it**:

There was no reference to the `SKIP_MODULE_LOAD` within the documentation. Moreover, it was renamed to `SKIP_DRIVER_LOADER` recently (https://github.com/falcosecurity/falco/pull/1297); thus, it's time to mention it under the "Running" section of the official documentation.
Finally, I also added a reference to the `DRIVER_REPO` env var under the same section since it can be useful in the same context.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Since the renaming (`SKIP_MODULE_LOAD` :point_right: `SKIP_DRIVER_LOADER`) will be effective when Falco 0.24.0 is released, keep this on
/hold
until then.

/cc @fntlnz 
/cc @leodido 