### PR TITLE
chore: bump falco version in docs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -317,7 +317,7 @@ languages:
       #  weight: 5
 
 params:
-  version: v0.23.0
+  version: v0.24.0
   githubRepository : falcosecurity/falco
   sha256sum: 21e8053c37e32f95d91c9393d961af1c63b5839d795c8cac314d05daadea9779
   primaryFont:


### PR DESCRIPTION
Signed-off-by: Spencer Krum <nibz@spencerkrum.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation


**What this PR does / why we need it**:

We didn't bump the version in `config.yaml` so when someone is on our docs it looks like they're seeing the 0.23.0 version of the docs not 0.24.0/master.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

I'll try to find where the release process docs are and add 'update config.yaml' in there.
