### PR TITLE
fix: template title to include the page title and not just the website title

### DIFF
--- a/themes/falco-fresh/layouts/_default/baseof.html
+++ b/themes/falco-fresh/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
   <head>
     {{ partial "ga.html"}}
     {{ partial "meta.html" . }}
-    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+    <title>{{ if eq .URL "/" }}{{ .Site.Title }}{{ else if eq .URL "/blog/" }}All Entries &middot; {{ .Site.Title }}{{ else }}{{ .Title }} - {{.Site.Title}}{{ end }}</title>
     {{ partial "css.html" . }}
   </head>
   <body{{ if $standard }} class="page has-navbar-fixed-top"{{ end }}>


### PR DESCRIPTION


Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>


**What type of PR is this?**


/kind user-interface




**What this PR does / why we need it**:
I noticed that every time I share a page of the website on the social media the title is always "The Falco Project" regardless the page.

With this PR I'm adjusting the things by:
- If it's home page, just input "The Falco Project"
- If it's the blog home page "All entries - The Falco Project"
- If it's an article or a page "Page title - The Falco Project"


**Which issue(s) this PR fixes**:



Fixes #

**Special notes for your reviewer**:
