### PR TITLE
update: make the kubecon keynote as featured

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,12 +46,12 @@ languages:
         title: Featured video
         subtitle: "Show more videos"
       videos:
+        - title: "Keynote: Open Source Intrusion Detection for Containers at Shopify"
+          youtubeVideoID: "6pVci31Mb6Q"
         - title: Designing a gRPC Interface for Kernel Tracing with eBPF
           youtubeVideoID: "kjOJfNDPVSo"
         - title: "Intro to Falco: Intrusion Detection for Containers"
           youtubeVideoID: "rBqBrYESryY"
-        - title: "Keynote: Open Source Intrusion Detection for Containers at Shopify"
-          youtubeVideoID: "6pVci31Mb6Q"
         - title: Cloud Native Runtime Security with Falco
           youtubeVideoID: "Z4POV5IXnHQ"
         - title: "Deep dive: Falco"
@@ -163,12 +163,12 @@ languages:
         title: 精选视频
         subtitle: "显示更多影片"
       videos:
+        - title: "Keynote: Open Source Intrusion Detection for Containers at Shopify"
+          youtubeVideoID: "6pVci31Mb6Q"
         - title: Designing a gRPC Interface for Kernel Tracing with eBPF
           youtubeVideoID: "kjOJfNDPVSo"
         - title: "Intro to Falco: Intrusion Detection for Containers"
           youtubeVideoID: "rBqBrYESryY"
-        - title: "Keynote: Open Source Intrusion Detection for Containers at Shopify"
-          youtubeVideoID: "6pVci31Mb6Q"
         - title: Cloud Native Runtime Security with Falco
           youtubeVideoID: "Z4POV5IXnHQ"
         - title: "Deep dive: Falco"
@@ -282,12 +282,12 @@ languages:
         title: 注目のビデオ
         subtitle: "他の動画を表示"
       videos:
+        - title: "Keynote: Open Source Intrusion Detection for Containers at Shopify"
+          youtubeVideoID: "6pVci31Mb6Q"
         - title: Designing a gRPC Interface for Kernel Tracing with eBPF
           youtubeVideoID: "kjOJfNDPVSo"
         - title: "Intro to Falco: Intrusion Detection for Containers"
           youtubeVideoID: "rBqBrYESryY"
-        - title: "Keynote: Open Source Intrusion Detection for Containers at Shopify"
-          youtubeVideoID: "6pVci31Mb6Q"
         - title: Cloud Native Runtime Security with Falco
           youtubeVideoID: "Z4POV5IXnHQ"
         - title: "Deep dive: Falco"


### PR DESCRIPTION
The reason why I'm featuring this talk is:

The Kubecon NA 2020 keynote is very representative of the current state
of art of Falco from an users point of view and also features an end
user use case from Shopify.

@kris-nova initially wanted to make this to the Falco home page too https://github.com/falcosecurity/falco-website/pull/251


Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>


**What type of PR is this?**



/kind content




**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:
