### PR TITLE
docs: A small touchup on the kube audit docs

### DIFF
--- a/content/en/docs/event-sources/kubernetes-audit.md
+++ b/content/en/docs/event-sources/kubernetes-audit.md
@@ -204,6 +204,8 @@ The output string is used to print essential information about the audit event, 
 * ConfigMap name: `%ka.req.configmap.name`
 * ConfigMap contents: `%ka.req.configmap.obj`
 
-# Enabling Kubernetes Audit Logs
+## Enabling Kubernetes Audit Logs
 
-In enable Kubernetes audit logs, you need to change the arguments to the `kube-apiserver` process to add `--audit-policy-file` and `--audit-webhook-config` arguments and provide files that implement an audit policy/webhook configuration. It is beyond the scope of Falco documentation to give a detailed description of how to do this, but the [example files](https://github.com/falcosecurity/evolution/blob/master/examples/k8s_audit_config/README.md) show how audit logging is added to minikube.
+To enable Kubernetes audit logs, you need to change the arguments to the `kube-apiserver` process to add `--audit-policy-file` and `--audit-webhook-config` arguments and provide files that implement an audit policy/webhook configuration. It is beyond the scope of Falco documentation to give a detailed description of how to do this, but the [example files](https://github.com/falcosecurity/evolution/blob/master/examples/k8s_audit_config/README.md) show how audit logging is added to minikube. Managed Kubernetes providers will usually provide a mechanism to configure the audit system.
+
+> Note: Dynamic Audit Webhooks were [removed](https://github.com/kubernetes/kubernetes/pull/91502) from Kubernetes. However, static audit configuration continues to work. 


### PR DESCRIPTION
This was mentioned in slack today. The double pound sign makes the
subheading clickable/linkable.

Signed-off-by: Spencer Krum <nibz@spencerkrum.com>


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

Was disucssed in slack
