### PR TITLE
update(content/en): falco-no-driver example to work with new `HOST_ROOT` default

### DIFF
--- a/content/en/docs/getting-started/running.md
+++ b/content/en/docs/getting-started/running.md
@@ -100,6 +100,7 @@ You can find more about its usage [here](/docs/getting-started/installation#inst
     ```shell
     docker pull falcosecurity/falco-no-driver:latest
     docker run --rm -i -t \
+        -e HOST_ROOT=/ \
         --cap-add SYS_PTRACE --pid=host $(ls /dev/falco* | xargs -I {} echo --device {}) \
         -v /var/run/docker.sock:/var/run/docker.sock \
         falcosecurity/falco-no-driver:latest
@@ -120,7 +121,7 @@ docker info | grep -i apparmor
 
 {{< info >}}
 
-Note that `ls /dev/falco* | xargs -I {} echo --device {}` outputs a `--device /dev/falcoX` option per CPU (ie. just the devices created by the Falco's kernel module).
+Note that `ls /dev/falco* | xargs -I {} echo --device {}` outputs a `--device /dev/falcoX` option per CPU (ie. just the devices created by the Falco's kernel module). Also, `-e HOST_ROOT=/` is necessary since with `--device` there is no way to remap devices to `/host/dev/`.
 
 {{< /info >}}
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

This is needed once https://github.com/falcosecurity/falco/pull/1492 gets merged.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

Do not merge before, since the docker sock path is related to the `HOST_ROOT` env variable that is currently missing in the falco-no-driver image as explained in https://github.com/falcosecurity/falco/issues/1491
/hold