### PR TITLE
update(content/en): add docker sock in "Run within Docker" section

### DIFF
--- a/content/en/docs/getting-started/running.md
+++ b/content/en/docs/getting-started/running.md
@@ -134,6 +134,7 @@ If you want to use Falco with the Kernel module driver
 docker pull falcosecurity/falco:latest
 docker run --rm -i -t \
     --privileged \
+    -v /var/run/docker.sock:/host/var/run/docker.sock \
     -v /dev:/host/dev \
     -v /proc:/host/proc:ro \
     -v /boot:/host/boot:ro \
@@ -150,6 +151,7 @@ docker pull falcosecurity/falco:latest
 docker run --rm -i -t \
     --privileged \
     -e FALCO_BPF_PROBE="" \
+    -v /var/run/docker.sock:/host/var/run/docker.sock \
     -v /dev:/host/dev \
     -v /proc:/host/proc:ro \
     -v /boot:/host/boot:ro \


### PR DESCRIPTION
**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

The "Run with Docker" examples for the "fully privileged" use case are missing `-v /var/run/docker.sock:/host/var/run/docker.sock`.
That should be present in those examples since it's a docker use case, and Falco uses container metadata by default.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
