### PR TITLE
Fix typo "Github" to "GitHub"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ languages:
         slackLink: https://slack.k8s.io/
         mailingListText: Developer Mailing List
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
-        communityText: Github Community
+        communityText: GitHub Community
         communityLink: https://github.com/falcosecurity/community
         privacyText: The Falco Community is bound to The Linux Foundation privacy policy. When you communicate with us (via email, phone, through the Sites or otherwise), we may maintain a record of your communication.
         privacyLink: https://www.linuxfoundation.org/privacy/
@@ -229,7 +229,7 @@ languages:
         slackLink: https://slack.k8s.io/
         mailingListText: Developer Mailing List
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
-        communityText: Github Community
+        communityText: GitHub Community
         communityLink: https://github.com/falcosecurity/community
         privacyText: The Falco Community is bound to The Linux Foundation privacy policy. When you communicate with us (via email, phone, through the Sites or otherwise), we may maintain a record of your communication.
         privacyLink: https://www.linuxfoundation.org/privacy/
@@ -351,7 +351,7 @@ languages:
         slackLink: https://slack.k8s.io/
         mailingListText: デベロッパーメーリングリスト
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
-        communityText: Github コミュニティ
+        communityText: GitHub コミュニティ
         communityLink: https://github.com/falcosecurity/community
         privacyText: The Falco Community is bound to The Linux Foundation privacy policy. When you communicate with us (via email, phone, through the Sites or otherwise), we may maintain a record of your communication.
         privacyLink: https://www.linuxfoundation.org/privacy/
@@ -473,7 +473,7 @@ languages:
         slackLink: https://slack.k8s.io/
         mailingListText: 개발자 메일링 리스트
         mailingListLink: https://lists.cncf.io/g/cncf-falco-dev
-        communityText: 깃헙(Github) 커뮤니티
+        communityText: 깃헙(GitHub) 커뮤니티
         communityLink: https://github.com/falcosecurity/community
         privacyText: The Falco Community is bound to The Linux Foundation privacy policy. When you communicate with us (via email, phone, through the Sites or otherwise), we may maintain a record of your communication.
         privacyLink: https://www.linuxfoundation.org/privacy/


### PR DESCRIPTION
Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

Current name is GitHub(Ref: https://github.com/) with the capital H. 
I want to fix this to make document better 🙇 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
