### PR TITLE
update: fix blog post slugs

### DIFF
--- a/content/en/blog/choosing-a-driver.md
+++ b/content/en/blog/choosing-a-driver.md
@@ -3,6 +3,7 @@ title: Choosing a Falco driver
 description: Understanding which Falco driver is right for you
 date: 2020-09-23
 author: Kris Nóva
+slug: choosing-a-driver
 ---
 
 Falco works by taking Linux system call information at runtime, and rebuilding the state of the kernel in memory.

--- a/content/en/blog/cloud-native-security-hub.md
+++ b/content/en/blog/cloud-native-security-hub.md
@@ -2,6 +2,7 @@
 title: Cloud Native Security Hub
 date: 2019-11-18
 author: Kris Nova
+slug: cloud-native-security-hub
 ---
 # Falco rules management 
 

--- a/content/en/blog/detect-cve-2020-8557.md
+++ b/content/en/blog/detect-cve-2020-8557.md
@@ -2,6 +2,7 @@
 Title: Detect CVE-2020-8557 using Falco
 Date: 2020-07-15
 Author: Kaizhe Huang
+slug: detect-cve-2020-8557
 ---
 
 # CVE-2020-8557

--- a/content/en/blog/extend-falco-outputs-with-falcosidekick.md
+++ b/content/en/blog/extend-falco-outputs-with-falcosidekick.md
@@ -2,6 +2,7 @@
 Title: Extend Falco outputs with falcosidekick
 Date: 2020-06-22
 Author: Thomas Labarussias
+slug: extend-falco-outputs-with-falcosidekick
 ---
 By default, Falco has 5 outputs for its events: **stdout**, **file**, **gRPC**, **shell** and **http**. As you see in the following diagram:
 

--- a/content/en/blog/falco-0-20-0.md
+++ b/content/en/blog/falco-0-20-0.md
@@ -2,6 +2,7 @@
 title: Falco 0.20.0 is released
 date: 2020-02-24
 author: Lorenzo Fontana
+slug: falco-0-20-0
 ---
 
 We're pleased to announce the release of Falco 0.20.0, our second release of 2020! Falco 0.20.0 consists of **a major bug fix**, a new feature, two minor bug fixes, and **seven** rules changes.

--- a/content/en/blog/falco-0-21-0.md
+++ b/content/en/blog/falco-0-21-0.md
@@ -2,6 +2,7 @@
 title: Falco 0.21.0 is out!
 date: 2020-03-18
 author: Leonardo Di Donato
+slug: falco-0-21-0
 ---
 
 Even though there's the lockdown, [Falco 0.21.0](https://github.com/falcosecurity/falco/releases/tag/0.21.0) decided to go out!

--- a/content/en/blog/falco-0-22-x.md
+++ b/content/en/blog/falco-0-22-x.md
@@ -2,6 +2,7 @@
 title: Falco 0.22 a.k.a. "the hard fixes release"
 date: 2020-04-17
 author: Leonardo Di Donato, Lorenzo Fontana
+slug: falco-0-22-x
 ---
 
 Another month has passed and Falco continues to grow!

--- a/content/en/blog/falco-0-23-0.md
+++ b/content/en/blog/falco-0-23-0.md
@@ -2,6 +2,7 @@
 title: Falco 0.23.0 a.k.a. "the artifacts scope release"
 date: 2020-05-18
 author: Leonardo Grasso, Lorenzo Fontana
+slug: falco-0-23-0
 ---
 
 Another month has passed and Falco continues to grow!

--- a/content/en/blog/falco-0-24-0.md
+++ b/content/en/blog/falco-0-24-0.md
@@ -2,6 +2,7 @@
 title: Falco 0.24.0 a.k.a. "the huge release"
 date: 2020-07-16
 author: Leonardo Di Donato, Leonardo Grasso
+slug: falco-0-24-0
 ---
 
 After two long months, look who's back!

--- a/content/en/blog/falco-0-25-0.md
+++ b/content/en/blog/falco-0-25-0.md
@@ -2,6 +2,7 @@
 title: Falco 0.25.0 a.k.a. "the summer release"
 date: 2020-08-25
 author: Lorenzo Fontana, Leonardo Grasso
+slug: falco-0-25-0
 ---
 
 

--- a/content/en/blog/falco-0-26-1.md
+++ b/content/en/blog/falco-0-26-1.md
@@ -2,6 +2,7 @@
 title: Falco 0.26.1 a.k.a. "the static release"
 date: 2020-10-01
 author: Leonardo Di Donato, Lorenzo Fontana
+slug: falco-0-26-1
 ---
 
 Today we announce the release of Falco 0.26.1 🥳

--- a/content/en/blog/falco-0-26-2.md
+++ b/content/en/blog/falco-0-26-2.md
@@ -2,6 +2,7 @@
 title: Falco 0.26.2 a.k.a. "the download.falco.org release"
 date: 2020-11-10
 author: Leonardo Di Donato, Lorenzo Fontana
+slug: falco-0-26-2
 ---
 
 Today we announce the release of Falco 0.26.2 🥳

--- a/content/en/blog/falco-2020.md
+++ b/content/en/blog/falco-2020.md
@@ -3,6 +3,7 @@ title: Falco in 2020
 description: Reviewing the progress of Falco and its community during the pandemic year
 date: 2021-01-03
 author: Leonardo Di Donato
+slug: falco-2020
 ---
 
 The scope of this post is to review the progress of Falco and its community during the pandemic year. A year will never forget.

--- a/content/en/blog/falco-in-the-open.md
+++ b/content/en/blog/falco-in-the-open.md
@@ -2,6 +2,7 @@
 title: Falco in the open
 date: 2019-08-27
 author: Kris Nova
+slug: falco-in-the-open
 ---
 <center>
 One of the most successful aspects of Kubernetes is how functional the open source community was able to operate. Kubernetes broke itself down in smaller sections called special interest groups, that operate similarly to subsections of the kernel. Each group is responsible for a single domain, and sets their own pace. One of the most important things to a [Kubernetes SIG](https://github.com/kubernetes/community/blob/master/sig-list.md), is the residual SIG calls. These are important opportunities for engineers across the industry to come together regardless of their employment status to work on building software. The structure of a SIG call varies from group to group, but all calls exist to [organize the engineers working in a particular space](https://kubernetes.io/docs/contribute/participating/).

--- a/content/en/blog/falco-kind-prometheus-grafana.md
+++ b/content/en/blog/falco-kind-prometheus-grafana.md
@@ -2,6 +2,7 @@
 title: Falco on Kind with Prometheus and Grafana
 date: 2020-03-19
 author: Leonardo Grasso
+slug: falco-kind-prometheus-grafana
 ---
 
 Kind is a tool for running local Kubernetes clusters using Docker container "nodes", that may be used for local development or CI. It also offers a convenient and easy way to install Falco in a Kubernetes cluster and play with it locally. We will use Kind to show how to export Falco metrics to Prometheus and Grafana.

--- a/content/en/blog/falco-scope.md
+++ b/content/en/blog/falco-scope.md
@@ -3,6 +3,7 @@ title: The Scope of Falco
 description: Understanding the scope of the Falco project
 date: 2020-04-20
 author: Kris Nóva
+slug: falco-scope
 ---
 
 As The Falco Project continues to grow, we are begining to understand the differences in engagement and support for our tooling.

--- a/content/en/blog/falco-security-audit.md
+++ b/content/en/blog/falco-security-audit.md
@@ -2,6 +2,7 @@
 title: Falco Security Audit
 date: 2019-12-16
 author: Michael Ducy
+slug: falco-security-audit
 ---
 Regularly auditing a code base is an important process in releasing secure software. Audits can be particularly important for open source projects that rely on code from a wide variety of contributors. We are happy to announce the release of Falco’s first [security audit](https://github.com/falcosecurity/falco/blob/master/audits/SECURITY_AUDIT_2019_07.pdf) which was performed through Falco’s participation as a [CNCF](https://www.cncf.io) Sandbox project. A big thanks to the CNCF for sponsoring the audit, and to the [Cure53](https://cure53.de/) team who performed the audit. 
 

--- a/content/en/blog/falco-wsl2-custom-kernel.md
+++ b/content/en/blog/falco-wsl2-custom-kernel.md
@@ -3,6 +3,7 @@ title: Falco on WSL2 with a custom kernel
 description: How to enable Falco kernel module on WSL2
 date: 2021-01-05
 author: Nuno do Carmo
+slug: falco-wsl2-custom-kernel
 ---
 
 # Falco on WSL2

--- a/content/en/blog/falcosideckick-joins-falcosecurity.md
+++ b/content/en/blog/falcosideckick-joins-falcosecurity.md
@@ -2,6 +2,7 @@
 Title: falcosidekick joins the falcosecurity organization
 Date: 2019-09-03
 Author: The Falco Authors
+slug: falcosideckick-joins-falcosecurity
 ---
 
 We are pleased to announce that [falcosidekick](https://github.com/falcosecurity/falcosidekick), a Go project aimed to forward [Falco](https://github.com/falcosecurity/falco) outputs to a number of services, joined the falcosecurity organization on GitHub.

--- a/content/en/blog/falcosidekick-2020.md
+++ b/content/en/blog/falcosidekick-2020.md
@@ -2,6 +2,7 @@
 title: Falcosidekick 2020
 date: 2021-01-12
 author: Thomas Labarussias
+slug: falcosidekick-2020
 ---
 
 This fantastic post from [@leodido](https://github.com/leodido) about how has been the previous year 2020 for falco inspired me ([link](https://falco.org/blog/falco-2020/))  I wanted to bring everyone up to speed on what we built for `falcosidekick` in 2020

--- a/content/en/blog/falcosidekick-kubeless.md
+++ b/content/en/blog/falcosidekick-kubeless.md
@@ -2,6 +2,7 @@
 title: Falcosidekick + Kubeless = a Kubernetes Response Engine
 date: 2021-01-15
 author: Thomas Labarussias
+slug: falcosidekick-kubeless
 ---
 
 Two years ago, we presented to you a `Kubernetes Response Engine` based on `Falco`. The idea was to trigger [`Kubeless`](https://kubeless.io) serverless functions for deleting infected pod, start a `Sysdig` capture or forward the `events` to `GCP PubSub`. See the [README](https://github.com/falcosecurity/kubernetes-response-engine).

--- a/content/en/blog/intro-k8s-security-monitoring.md
+++ b/content/en/blog/intro-k8s-security-monitoring.md
@@ -4,6 +4,7 @@ description: A quick introduction to Kubernetes security monitoring using Falco
 date: 2021-01-07
 author: Frederick Fernando
 canonical_url: https://www.infracloud.io/blogs/introduction-kubernetes-security-falco/
+slug: intro-k8s-security-monitoring
 ---
 
 ## Let’s talk about Kubernetes security

--- a/content/en/blog/minikube-falco-kernel-module.md
+++ b/content/en/blog/minikube-falco-kernel-module.md
@@ -2,6 +2,7 @@
 title: Minikube 1.8.0 packages the Falco Kernel Module
 date: 2020-03-08
 author: Lorenzo Fontana
+slug: minikube-falco-kernel-module
 ---
 
 Minikube is a tool that implements a local Kubernetes cluster on macOS, Linux and Windows via a simple command line, it is

--- a/content/en/blog/security-boundaries-with-systemd-and-kubernetes.md
+++ b/content/en/blog/security-boundaries-with-systemd-and-kubernetes.md
@@ -3,6 +3,7 @@ title: Security boundaries with Kubernetes and systemd
 description: Understanding why I do not run Falco in Kubernetes
 date: 2020-12-10
 author: Kris Nóva
+slug: security-boundaries-with-systemd-and-kubernetes
 ---
 
 # A familiar scenario


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**


/kind bug



**Any specific area of the project related to this PR?**


/area blog



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fix an issue reported by @Issif on the slack channel where our new website blog urls are not matching the old website ones.

I had to add a specific slug for every old blog post to reflect what it had in the old blog because we already have the 0.27.0 release blog post out on social and because of that we now had two different schemes deployed.

I think this is also a good opportunity to remember that the `slug: ` tag exists in Hugo and that we can use that to create more friendly URLs instead of using what hugo gives.

**Special notes for your reviewer**:
