### PR TITLE
Update learning.md

### DIFF
--- a/content/en/docs/getting-started/third-party/learning.md
+++ b/content/en/docs/getting-started/third-party/learning.md
@@ -114,12 +114,12 @@ To run Falco on a `kind` cluster is as follows:
     apiVersion: kind.x-k8s.io/v1alpha4
     nodes:
     - role: control-plane
-    extraMounts:
+      extraMounts:
         # allow Falco to use devices provided by the kernel module
-        - hostPath: /dev
+      - hostPath: /dev
         containerPath: /dev
         # allow Falco to use the Docker unix socket
-        - hostPath: /var/run/docker.sock
+      - hostPath: /var/run/docker.sock
         containerPath: /var/run/docker.sock
     ```
 


### PR DESCRIPTION
addressing yaml indentation issue.  correct should be something like this:

```kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraMounts:
  - hostPath: /dev
    containerPath: /dev
  - hostPath: /var/run/docker.sock
    containerPath: /var/run/docker.sock```

Signed-off-by: Dan Papandrea  <dan.papandrea@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

> /area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
