### PR TITLE
Switch download links and packages repos to download.falco.org

### DIFF
--- a/content/en/blog/exceptions.md
+++ b/content/en/blog/exceptions.md
@@ -179,3 +179,5 @@ Along with this code change, we've also revamped the rules to migrate as many ru
 We have a more complete description of how exceptions work in the [documentation](https://falco.org/docs/rules/exceptions) along with best practices for adding exceptions to rules. You can also read the original [proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20200828-structured-exception-handling.md) describes the benefits of exceptions in more detail.
 
 In case you prefer to just try them out please notice you need Falco 0.27.0-15+8c4040b ([deb](https://bintray.com/falcosecurity/deb-dev/falco/0.27.0-15%2B8c4040b), [rpm](https://bintray.com/falcosecurity/rpm-dev/falco/0.27.0-15%2B8c4040b), [tarball](https://bintray.com/falcosecurity/bin-dev/falco/0.27.0-15%2B8c4040b)).
+
+**March 2021 update**: All packages are now published to [download.falco.org](https://download.falco.org/?prefix=packages/).

--- a/content/en/blog/exceptions.md
+++ b/content/en/blog/exceptions.md
@@ -178,6 +178,4 @@ Along with this code change, we've also revamped the rules to migrate as many ru
 
 We have a more complete description of how exceptions work in the [documentation](https://falco.org/docs/rules/exceptions) along with best practices for adding exceptions to rules. You can also read the original [proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20200828-structured-exception-handling.md) describes the benefits of exceptions in more detail.
 
-In case you prefer to just try them out please notice you need Falco 0.27.0-15+8c4040b ([deb](https://bintray.com/falcosecurity/deb-dev/falco/0.27.0-15%2B8c4040b), [rpm](https://bintray.com/falcosecurity/rpm-dev/falco/0.27.0-15%2B8c4040b), [tarball](https://bintray.com/falcosecurity/bin-dev/falco/0.27.0-15%2B8c4040b)).
-
-**March 2021 update**: All packages are now published to [download.falco.org](https://download.falco.org/?prefix=packages/).
+In case you prefer to just try them out please notice you need Falco 0.27.0-15+8c4040b ([deb](https://download.falco.org/packages/deb-dev/stable/falco-0.27.0-15%2B8c4040b-x86_64.deb), [rpm](https://download.falco.org/packages/rpm-dev/falco-0.27.0-15%2B8c4040b-x86_64.rpm), [tarball](https://download.falco.org/packages/bin-dev/x86_64/falco-0.27.0-19%2B959811a-x86_64.tar.gz)).

--- a/content/en/blog/falco-0-21-0.md
+++ b/content/en/blog/falco-0-21-0.md
@@ -59,6 +59,8 @@ When one of these two conditions happen:
    1. `falcosecurity/falco:master`, `falcosecurity/falco:master-slim`, `falcosecurity/falco:master-minimal` for _development_ versions
    2. `falcosecurity/falco:latest`, `falcosecurity/falco:latest-slim`, `falcosecurity/falco:latest-minimal` for _stable_ versions
 
+**March 2021 update**: All packages are now published to [download.falco.org](https://download.falco.org/?prefix=packages/).
+
 ### FALCO_BPF_PROBE
 
 Thanks to [Lorenzo](https://github.com/fntlnz) contribution (PR [1050](https://github.com/falcosecurity/falco/pull/1050)),

--- a/content/en/blog/falco-2020.md
+++ b/content/en/blog/falco-2020.md
@@ -26,7 +26,7 @@ While moving the release process in the open, we also took the chance to:
 - separate the Falco drivers version from the Falco version
 - rename the drivers in a more coherent way
 - reorganize its artifacts
-- every merge on the master branch and every new release create Falco packages automatically now and push them to package repositories (tarball, DEB, and RPM) on [Bintray](https://bintray.com/falcosecurity) 📦
+- every merge on the master branch and every new release create Falco packages automatically now and push them to package repositories (tarball, DEB, and RPM) on [download.falco.org](https://download.falco.org/?prefix=packages) 📦
 - reorganize its container images
 - every merge on the master branch and every new release, automatically build and publish container images on the [DockerHub](https://hub.docker.com/u/falcosecurity) 🐳
 - soon on the [AWS ECR Gallery](https://gallery.ecr.aws/falcosecurity/falco), too ([1512](https://github.com/falcosecurity/falco/pull/1512) soon to be merged in!)

--- a/content/en/blog/falco-security-and-monitoring-on-rke-bare-metal-cluster-with-rancher.md
+++ b/content/en/blog/falco-security-and-monitoring-on-rke-bare-metal-cluster-with-rancher.md
@@ -48,7 +48,7 @@ Adding the Falco repository:
 
 ```bash
 curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
-echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
 apt-get update -y
 ```
 

--- a/content/en/blog/falco-wsl2-custom-kernel.md
+++ b/content/en/blog/falco-wsl2-custom-kernel.md
@@ -202,7 +202,7 @@ cd
 
 # Run the step 1 of the Falco documentation: add the repo
 curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | sudo apt-key add -
-echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | sudo tee -a /etc/apt/sources.list.d/falcosecurity.list
+echo "deb https://download.falco.org/packages/deb stable main" | sudo tee -a /etc/apt/sources.list.d/falcosecurity.list
 sudo apt update
 
 # As stated above, for the step 2, let's download the Kernel headers packages

--- a/content/en/docs/getting-started/download.md
+++ b/content/en/docs/getting-started/download.md
@@ -14,7 +14,6 @@ Below you can find artifacts for both.
 
 ### Download for Linux {#packages}
 
-
 |        | development                                                                                                                 | stable                                                                                                              |
 |--------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | rpm    | [![rpm-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm-dev%2Ffalco-)][1] | [![rpm](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm%2Ffalco-)][2] |

--- a/content/en/docs/getting-started/download.md
+++ b/content/en/docs/getting-started/download.md
@@ -47,9 +47,9 @@ For more details, see the [Run within Docker section](/docs/getting-started/runn
 
 The list of all available images can be found [here](https://github.com/falcosecurity/falco/tree/master/docker).
 
-[1]: https://dl.bintray.com/falcosecurity/rpm-dev
-[2]: https://dl.bintray.com/falcosecurity/rpm
-[3]: https://dl.bintray.com/falcosecurity/deb-dev/stable
-[4]: https://dl.bintray.com/falcosecurity/deb/stable
-[5]: https://dl.bintray.com/falcosecurity/bin-dev/x86_64
-[6]: https://dl.bintray.com/falcosecurity/bin/x86_64
+[1]: https://download.falco.org/packages/rpm-dev
+[2]: https://download.falco.org/packages/rpm
+[3]: https://download.falco.org/packages/deb-dev/stable
+[4]: https://download.falco.org/packages/deb/stable
+[5]: https://download.falco.org/packages/bin-dev/x86_64
+[6]: https://download.falco.org/packages/bin/x86_64

--- a/content/en/docs/getting-started/download.md
+++ b/content/en/docs/getting-started/download.md
@@ -14,13 +14,14 @@ Below you can find artifacts for both.
 
 ### Download for Linux {#packages}
 
+
 |        | development                                                                                                                 | stable                                                                                                              |
 |--------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| rpm    | [![rpm-dev](https://img.shields.io/bintray/v/falcosecurity/rpm-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][1] | [![rpm](https://img.shields.io/bintray/v/falcosecurity/rpm/falco?label=Falco&color=%23005763&style=flat-square)][2] |
-| deb    | [![deb-dev](https://img.shields.io/bintray/v/falcosecurity/deb-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][3] | [![deb](https://img.shields.io/bintray/v/falcosecurity/deb/falco?label=Falco&color=%23005763&style=flat-square)][4] |
-| binary | [![bin-dev](https://img.shields.io/bintray/v/falcosecurity/bin-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][5] | [![bin](https://img.shields.io/bintray/v/falcosecurity/bin/falco?label=Falco&color=%23005763&style=flat-square)][6] |
+| rpm    | [![rpm-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm-dev%2Ffalco-)][1] | [![rpm](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm%2Ffalco-)][2] |
+| deb    | [![deb-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb-dev%2Fstable%2Ffalco-)][3] | [![deb](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb%2Fstable%2Ffalco-)][4] |
+| binary | [![bin-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin-dev%2Fx86_64%2Ffalco-)][5] | [![bin](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin%2Fx86_64%2Ffalco-)][6] |
 
-The list of all available artifacts can be found [here](https://bintray.com/falcosecurity).
+The list of all available artifacts can be found [here](https://download.falco.org/?prefix=packages/).
 
 ---
 
@@ -47,9 +48,9 @@ For more details, see the [Run within Docker section](/docs/getting-started/runn
 
 The list of all available images can be found [here](https://github.com/falcosecurity/falco/tree/master/docker).
 
-[1]: https://download.falco.org/packages/rpm-dev
-[2]: https://download.falco.org/packages/rpm
-[3]: https://download.falco.org/packages/deb-dev/stable
-[4]: https://download.falco.org/packages/deb/stable
-[5]: https://download.falco.org/packages/bin-dev/x86_64
-[6]: https://download.falco.org/packages/bin/x86_64
+[1]: https://download.falco.org/?prefix=packages/rpm-dev/
+[2]: https://download.falco.org/?prefix=packages/rpm/
+[3]: https://download.falco.org/?prefix=packages/deb-dev/stable/
+[4]: https://download.falco.org/?prefix=packages/deb/stable/
+[5]: https://download.falco.org/?prefix=packages/bin-dev/x86_64/
+[6]: https://download.falco.org/?prefix=packages/bin/x86_64/

--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Alternatively, it is also possible to use a binary package as [explained below](
 
     ```shell
     curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
-    echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+    echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
     apt-get update -y
     ```
 
@@ -131,7 +131,7 @@ Alternatively, it is also possible to use a binary package as [explained below](
 1. Download the latest binary:
 
     ```shell
-    curl -L -O https://dl.bintray.com/falcosecurity/bin/x86_64/falco-{{< latest >}}-x86_64.tar.gz
+    curl -L -O https://download.falco.org/packages/bin/x86_64/falco-{{< latest >}}-x86_64.tar.gz
     ```
 
 2. Install Falco:

--- a/content/en/docs/getting-started/upgrade.md
+++ b/content/en/docs/getting-started/upgrade.md
@@ -4,16 +4,36 @@ description: Upgrading Falco on a Linux system
 weight: 3
 ---
 
+This section provides upgrading paths for Falco if previously installed following the [Install](../installation/) section. 
+
 ## Upgrading
 
 ### Debian/Ubuntu {#debian}
 
-*TODO*
+{{% pageinfo color="warning" %}}
+If you configured the `apt` repository by having followed the instructions for Falco 0.27.0 or older, 
+you may need to update the repository URL:
+
+```shell
+sed -i 's,https://dl.bintray.com/falcosecurity/deb,https://download.falco.org/packages/deb,' /etc/apt/sources.list.d/falcosecurity.list
+apt-get clean
+apt-get -y update
+```
+
+Check in the `apt-get update` log that `https://download.falco.org/packages/deb` is present.
+
+{{% /pageinfo %}}
+
+If you installed Falco by following the [provided instructions](../installation/#debian):
+
+```shell
+apt-get --only-upgrade install falco
+```
 
 ### CentOS/RHEL/Fedora/Amazon Linux {#centos-rhel}
 
 {{% pageinfo color="warning" %}}
-If you configured the yum repository by having followed the instructions for Falco 0.27.0 or older, 
+If you configured the `yum` repository by having followed the instructions for Falco 0.27.0 or older, 
 you may need to update the repository URL:
 
 ```shell

--- a/content/en/docs/getting-started/upgrade.md
+++ b/content/en/docs/getting-started/upgrade.md
@@ -1,0 +1,41 @@
+---
+title: Upgrade
+description: Upgrading Falco on a Linux system
+weight: 3
+---
+
+## Upgrading
+
+### Debian/Ubuntu {#debian}
+
+*TODO*
+
+### CentOS/RHEL/Fedora/Amazon Linux {#centos-rhel}
+
+{{% pageinfo color="warning" %}}
+If you configured the yum repository by having followed the instructions for Falco 0.27.0 or older, 
+you may need to update the repository URL:
+
+```shell
+sed -i 's,https://dl.bintray.com/falcosecurity/rpm,https://download.falco.org/packages/rpm,' /etc/yum.repos.d/falcosecurity.repo
+yum clean all
+```
+
+Then check that the `falcosecurity-rpm` repository is pointing to `https://download.falco.org/packages/rpm/`:
+
+```shell
+yum repolist -v falcosecurity-rpm
+```
+{{% /pageinfo %}}
+
+If you installed Falco by following the [provided instructions](../installation/#centos-rhel):
+
+1. Check for updates:
+    ```shell
+    yum check-update
+    ```
+
+2. If a newer Falco version is available:
+    ```shell
+    yum update falco
+    ```

--- a/content/ja/blog/exceptions.md
+++ b/content/ja/blog/exceptions.md
@@ -179,3 +179,5 @@ filenamesは、単一のフィールドと単一の比較演算子を指定す�
 例外がどのように機能するのかについては、[ドキュメント](https://falco.org/docs/rules/exceptions) に、ルールに例外を追加するためのベストプラクティスとともに、より完全な説明があります。また、オリジナルの [proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20200828-structured-exception-handling.md) には、例外の利点をより詳細に説明しています。
 
 例外を試してみたい場合は、Falco 0.27.0-15+8c4040b ([deb](https://bintray.com/falcosecurity/deb-dev/falco/0.27.0-15%2B8c4040b), [rpm](https://bintray.com/falcosecurity/rpm-dev/falco/0.27.0-15%2B8c4040b), [tarball](https://bintray.com/falcosecurity/bin-dev/falco/0.27.0-15%2B8c4040b))が必要です。
+
+**March 2021 update**: All packages are now published to [download.falco.org](https://download.falco.org/?prefix=packages/).

--- a/content/ja/blog/exceptions.md
+++ b/content/ja/blog/exceptions.md
@@ -178,6 +178,4 @@ filenamesは、単一のフィールドと単一の比較演算子を指定す�
 
 例外がどのように機能するのかについては、[ドキュメント](https://falco.org/docs/rules/exceptions) に、ルールに例外を追加するためのベストプラクティスとともに、より完全な説明があります。また、オリジナルの [proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20200828-structured-exception-handling.md) には、例外の利点をより詳細に説明しています。
 
-例外を試してみたい場合は、Falco 0.27.0-15+8c4040b ([deb](https://bintray.com/falcosecurity/deb-dev/falco/0.27.0-15%2B8c4040b), [rpm](https://bintray.com/falcosecurity/rpm-dev/falco/0.27.0-15%2B8c4040b), [tarball](https://bintray.com/falcosecurity/bin-dev/falco/0.27.0-15%2B8c4040b))が必要です。
-
-**March 2021 update**: All packages are now published to [download.falco.org](https://download.falco.org/?prefix=packages/).
+例外を試してみたい場合は、Falco 0.27.0-15+8c4040b ([deb](https://download.falco.org/packages/deb-dev/stable/falco-0.27.0-15%2B8c4040b-x86_64.deb), [rpm](https://download.falco.org/packages/rpm-dev/falco-0.27.0-15%2B8c4040b-x86_64.rpm), [tarball](https://download.falco.org/packages/bin-dev/x86_64/falco-0.27.0-19%2B959811a-x86_64.tar.gz))が必要です。

--- a/content/ja/blog/falco-2020.md
+++ b/content/ja/blog/falco-2020.md
@@ -25,7 +25,7 @@ author: Leonardo Di Donato
 - Falcoドライバー版とFalco版を分ける
 - ドライバーの名前をより一貫性のある方法で変更します。
 - アーティファクトを再構築する
-- マスターブランチでのマージと新しいリリースのたびに、自動的に Falco パッケージを作成し、[Bintray](https://bintray.com/falcosecurity) のパッケージリポジトリ (tarball, DEB, RPM) にプッシュするようになりました。📦
+- マスターブランチでのマージと新しいリリースのたびに、自動的に Falco パッケージを作成し、[download.falco.org](https://download.falco.org/?prefix=packages) のパッケージリポジトリ (tarball, DEB, RPM) にプッシュするようになりました。📦
 - コンテナのイメージを再編成する
 - マスターブランチへのマージや新しいリリースのたびに、コンテナイメージを自動的にビルドして [DockerHub](https://hub.docker.com/u/falcosecurity) 🐳に公開します。
 - AWS ECR Gallery](https://gallery.ecr.aws/falcosecurity/falco)にも近日公開予定です ([1512](https://github.com/falcosecurity/falco/pull/1512)にも近日中に統合予定です)

--- a/content/ja/blog/falco-wsl2-custom-kernel.md
+++ b/content/ja/blog/falco-wsl2-custom-kernel.md
@@ -202,7 +202,7 @@ cd
 
 # Falcoドキュメントのステップ1を実行します: repoを追加します
 curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | sudo apt-key add - -を追加します。
-echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | sudo tee -a /etc/apt/sources.list.d/falcosecurity.list
+echo "deb https://download.falco.org/packages/deb stable main" | sudo tee -a /etc/apt/sources.list.d/falcosecurity.list
 sudo apt update
 
 # 上記の通り、ステップ2では、カーネルヘッダパッケージをダウンロードしてみましょう

--- a/content/ja/docs/event-sources/kernel-module.md
+++ b/content/ja/docs/event-sources/kernel-module.md
@@ -12,7 +12,7 @@ Falcoは、`falco`と呼ばれる独自のカーネルモジュールを使用�
 デフォルトでは、カーネルモジュールは、falco debian/redhatパッケージをインストールするとき、または `falcosecurity/falco` Dockerイメージを実行するときにインストールされます。カーネルモジュールをインストールするスクリプトは、次の3つの方法でインストールを試みます：
 
 * [dkms](https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support)を使用して、ソースからカーネルモジュールをビルドします。
-* ビルド済みのカーネルモジュールを`https://dl.bintray.com/falcosecurity/driver/`からダウンロードします。
+* ビルド済みのカーネルモジュールを`https://download.falco.org/driver/`からダウンロードします。
 * `~/.falco`からビルド済みのカーネルモジュールを探します。
 
 ビルド済みのカーネルモジュールを使用するオプションについては、[インストール](//docs/installation/)ページをご覧ください。

--- a/content/ja/docs/getting-started/download.md
+++ b/content/ja/docs/getting-started/download.md
@@ -18,11 +18,12 @@ Falcoプロジェクトコミュニティは、Falcoをダウンロードして�
 
 |        | development                                                                                                                 | stable                                                                                                              |
 |--------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| rpm    | [![rpm-dev](https://img.shields.io/bintray/v/falcosecurity/rpm-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][1] | [![rpm](https://img.shields.io/bintray/v/falcosecurity/rpm/falco?label=Falco&color=%23005763&style=flat-square)][2] |
-| deb    | [![deb-dev](https://img.shields.io/bintray/v/falcosecurity/deb-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][3] | [![deb](https://img.shields.io/bintray/v/falcosecurity/deb/falco?label=Falco&color=%23005763&style=flat-square)][4] |
-| binary | [![bin-dev](https://img.shields.io/bintray/v/falcosecurity/bin-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][5] | [![bin](https://img.shields.io/bintray/v/falcosecurity/bin/falco?label=Falco&color=%23005763&style=flat-square)][6] |
+| rpm    | [![rpm-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm-dev%2Ffalco-)][1] | [![rpm](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm%2Ffalco-)][2] |
+| deb    | [![deb-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb-dev%2Fstable%2Ffalco-)][3] | [![deb](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb%2Fstable%2Ffalco-)][4] |
+| binary | [![bin-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin-dev%2Fx86_64%2Ffalco-)][5] | [![bin](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin%2Fx86_64%2Ffalco-)][6] |
 
-利用可能なすべてのアーティファクトのリストは、[こちら](https://bintray.com/falcosecurity)にあります。
+
+利用可能なすべてのアーティファクトのリストは、[こちら](https://download.falco.org/?prefix=packages/)にあります。
 
 ---
 
@@ -50,9 +51,9 @@ Falcoは、実行中のシステムコールに関する情報を取得するた
 
 利用可能なすべてのイメージのリストは、[こちら](https://github.com/falcosecurity/falco/tree/master/docker)にあります。
 
-[1]: https://download.falco.org/packages/rpm-dev
-[2]: https://download.falco.org/packages/rpm
-[3]: https://download.falco.org/packages/deb-dev/stable
-[4]: https://download.falco.org/packages/deb/stable
-[5]: https://download.falco.org/packages/bin-dev/x86_64
-[6]: https://download.falco.org/packages/bin/x86_64
+[1]: https://download.falco.org/?prefix=packages/rpm-dev/
+[2]: https://download.falco.org/?prefix=packages/rpm/
+[3]: https://download.falco.org/?prefix=packages/deb-dev/stable/
+[4]: https://download.falco.org/?prefix=packages/deb/stable/
+[5]: https://download.falco.org/?prefix=packages/bin-dev/x86_64/
+[6]: https://download.falco.org/?prefix=packages/bin/x86_64/

--- a/content/ja/docs/getting-started/download.md
+++ b/content/ja/docs/getting-started/download.md
@@ -50,9 +50,9 @@ Falcoは、実行中のシステムコールに関する情報を取得するた
 
 利用可能なすべてのイメージのリストは、[こちら](https://github.com/falcosecurity/falco/tree/master/docker)にあります。
 
-[1]: https://dl.bintray.com/falcosecurity/rpm-dev
-[2]: https://dl.bintray.com/falcosecurity/rpm
-[3]: https://dl.bintray.com/falcosecurity/deb-dev/stable
-[4]: https://dl.bintray.com/falcosecurity/deb/stable
-[5]: https://dl.bintray.com/falcosecurity/bin-dev/x86_64
-[6]: https://dl.bintray.com/falcosecurity/bin/x86_64
+[1]: https://download.falco.org/packages/rpm-dev
+[2]: https://download.falco.org/packages/rpm
+[3]: https://download.falco.org/packages/deb-dev/stable
+[4]: https://download.falco.org/packages/deb/stable
+[5]: https://download.falco.org/packages/bin-dev/x86_64
+[6]: https://download.falco.org/packages/bin/x86_64

--- a/content/ja/docs/getting-started/installation.md
+++ b/content/ja/docs/getting-started/installation.md
@@ -32,7 +32,7 @@ Kind、Minikube、Helmなどのツールを使用してKubernetesで直接Falco�
 
     ```shell
     curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
-    echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+    echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
     apt-get update -y
     ```
 
@@ -100,7 +100,7 @@ Kind、Minikube、Helmなどのツールを使用してKubernetesで直接Falco�
 1. 最新のバイナリをダウンロード:
 
     ```shell
-    curl -L -O https://dl.bintray.com/falcosecurity/bin/x86_64/falco-{{< latest >}}-x86_64.tar.gz
+    curl -L -O https://download.falco.org/packages/bin/x86_64/falco-{{< latest >}}-x86_64.tar.gz
     ```
 
 2. Falcoのインストール:

--- a/content/ko/docs/download.md
+++ b/content/ko/docs/download.md
@@ -48,9 +48,9 @@ weight: 2
 
 사용 가능한 전체 이미지 목록은 [여기](https://github.com/falcosecurity/falco/tree/master/docker)에서 확인할 수 있다.
 
-[1]: https://dl.bintray.com/falcosecurity/rpm-dev
-[2]: https://dl.bintray.com/falcosecurity/rpm
-[3]: https://dl.bintray.com/falcosecurity/deb-dev/stable
-[4]: https://dl.bintray.com/falcosecurity/deb/stable
-[5]: https://dl.bintray.com/falcosecurity/bin-dev/x86_64
-[6]: https://dl.bintray.com/falcosecurity/bin/x86_64
+[1]: https://download.falco.org/packages/rpm-dev
+[2]: https://download.falco.org/packages/rpm
+[3]: https://download.falco.org/packages/deb-dev/stable
+[4]: https://download.falco.org/packages/deb/stable
+[5]: https://download.falco.org/packages/bin-dev/x86_64
+[6]: https://download.falco.org/packages/bin/x86_64

--- a/content/ko/docs/download.md
+++ b/content/ko/docs/download.md
@@ -17,11 +17,12 @@ weight: 2
 
 |        | development                                                                                                                 | stable                                                                                                              |
 |--------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| rpm    | [![rpm-dev](https://img.shields.io/bintray/v/falcosecurity/rpm-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][1] | [![rpm](https://img.shields.io/bintray/v/falcosecurity/rpm/falco?label=Falco&color=%23005763&style=flat-square)][2] |
-| deb    | [![deb-dev](https://img.shields.io/bintray/v/falcosecurity/deb-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][3] | [![deb](https://img.shields.io/bintray/v/falcosecurity/deb/falco?label=Falco&color=%23005763&style=flat-square)][4] |
-| binary | [![bin-dev](https://img.shields.io/bintray/v/falcosecurity/bin-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][5] | [![bin](https://img.shields.io/bintray/v/falcosecurity/bin/falco?label=Falco&color=%23005763&style=flat-square)][6] |
+| rpm    | [![rpm-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm-dev%2Ffalco-)][1] | [![rpm](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm%2Ffalco-)][2] |
+| deb    | [![deb-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb-dev%2Fstable%2Ffalco-)][3] | [![deb](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb%2Fstable%2Ffalco-)][4] |
+| binary | [![bin-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin-dev%2Fx86_64%2Ffalco-)][5] | [![bin](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin%2Fx86_64%2Ffalco-)][6] |
 
-사용 가능한 전체 아티팩트 목록은 [여기](https://bintray.com/falcosecurity)에서 확인할 수 있다.
+
+사용 가능한 전체 아티팩트 목록은 [여기](https://download.falco.org/?prefix=packages)에서 확인할 수 있다.
 
 ---
 
@@ -48,9 +49,9 @@ weight: 2
 
 사용 가능한 전체 이미지 목록은 [여기](https://github.com/falcosecurity/falco/tree/master/docker)에서 확인할 수 있다.
 
-[1]: https://download.falco.org/packages/rpm-dev
-[2]: https://download.falco.org/packages/rpm
-[3]: https://download.falco.org/packages/deb-dev/stable
-[4]: https://download.falco.org/packages/deb/stable
-[5]: https://download.falco.org/packages/bin-dev/x86_64
-[6]: https://download.falco.org/packages/bin/x86_64
+[1]: https://download.falco.org/?prefix=packages/rpm-dev/
+[2]: https://download.falco.org/?prefix=packages/rpm/
+[3]: https://download.falco.org/?prefix=packages/deb-dev/stable/
+[4]: https://download.falco.org/?prefix=packages/deb/stable/
+[5]: https://download.falco.org/?prefix=packages/bin-dev/x86_64/
+[6]: https://download.falco.org/?prefix=packages/bin/x86_64/

--- a/content/ko/docs/installation.md
+++ b/content/ko/docs/installation.md
@@ -32,7 +32,7 @@ Kind, Minikube, Helm 같은 도구를 이용해 팔코를 쿠버네티스에서 
 
     ```shell
     curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
-    echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+    echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
     apt-get update -y
     ```
 
@@ -100,7 +100,7 @@ Kind, Minikube, Helm 같은 도구를 이용해 팔코를 쿠버네티스에서 
 1. 최신 바이너리를 다운로드한다.
 
     ```shell
-    curl -L -O https://dl.bintray.com/falcosecurity/bin/x86_64/falco-{{< latest >}}-x86_64.tar.gz
+    curl -L -O https://download.falco.org/packages/bin/x86_64/falco-{{< latest >}}-x86_64.tar.gz
     ```
 
 2. 팔코를 설치한다.

--- a/content/zh/docs/installation.md
+++ b/content/zh/docs/installation.md
@@ -249,11 +249,11 @@ sudo bash install_falco
 
    ```shell
     curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
-    echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+    echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
     apt-get update -y
     ```
 
-    > **注意** - 如果您希望使用来自当前主服务器的Falco包将https://dl.bintray.com/falcosecurity/deb-dev地址输入到falcosecurity.list文件中。
+    > **注意** - 如果您希望使用来自当前主服务器的Falco包将https://download.falco.org/packages/deb-dev地址输入到falcosecurity.list文件中。
 
 2. 安装内核头：
 

--- a/static/repo/falcosecurity-rpm-dev.repo
+++ b/static/repo/falcosecurity-rpm-dev.repo
@@ -1,7 +1,7 @@
 # falcosecurity-rpm-dev - dev packages by falcosecurity
 [falcosecurity-rpm-dev]
 name=falcosecurity-rpm
-baseurl=https://dl.bintray.com/falcosecurity/rpm-dev
+baseurl=https://download.falco.org/packages/rpm-dev
 gpgcheck=1
 gpgkey=https://falco.org/repo/falcosecurity-3672BA8F.asc
 repo_gpgcheck=0

--- a/static/repo/falcosecurity-rpm.repo
+++ b/static/repo/falcosecurity-rpm.repo
@@ -1,7 +1,7 @@
 # falcosecurity-rpm - packages by falcosecurity
 [falcosecurity-rpm]
 name=falcosecurity-rpm
-baseurl=https://dl.bintray.com/falcosecurity/rpm
+baseurl=https://download.falco.org/packages/rpm
 gpgcheck=1
 gpgkey=https://falco.org/repo/falcosecurity-3672BA8F.asc
 repo_gpgcheck=0

--- a/static/script/install
+++ b/static/script/install
@@ -62,7 +62,7 @@ function install_deb {
 	echo "* Installing Falco public GPG key"
 	curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
 	echo "* Installing Falco repository"
-	echo "deb https://dl.bintray.com/falcosecurity/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+	echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
 	apt-get -qq update < /dev/null
 	echo "* Installing kernel headers"
 	apt-get -qq -y install "linux-headers-$(uname -r)" < /dev/null || kernel_warning


### PR DESCRIPTION
**What type of PR is this?**

/kind content


**Any specific area of the project related to this PR?**


/area blog

/area documentation



**What this PR does / why we need it**:

This is part of the migration from Bintray to our in-house solution `download.falco.org`.
Also, it adds upgrade paths for Falco (as suggested by @fntlnz )

**Special notes for your reviewer**:

To be merged after https://github.com/falcosecurity/falco/issues/1567 has been completed.
/hold
/cc @fntlnz 
/cc @leodido 