### PR TITLE
Use git --depth and --branch flags to save space/time

### DIFF
--- a/content/en/blog/falco-wsl2-custom-kernel.md
+++ b/content/en/blog/falco-wsl2-custom-kernel.md
@@ -68,8 +68,9 @@ cd
 sudo apt install -y build-essential flex bison libssl-dev libelf-dev
 
 # Get the latest stable Linux Kernel
+# Save lots of space and bandwith by fetching only the latest version of each file on the linux-rolling-stable branch
 # git needs to be installed
-git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+git clone --depth 1 --branch linux-rolling-stable https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
 
 # Ensure the "stable" branch is the active one
 cd linux


### PR DESCRIPTION
By default, git will clone the full history of the Linux kernel.  Using the --depth and --branch flags allows us to clone exactly what we need, greatly saving both disk space and network I/O.

Signed-off-by: Karl Magdsick <karl@magdsick.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

This makes the instructions work much faster on slow internet connections.  My ISP seems to have started throttling the connection part way through cloning the full Linux kernel history.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:
