### PR TITLE
Use git --depth and --branch flags to save space/time

### DIFF
--- a/content/en/blog/falco-wsl2-custom-kernel.md
+++ b/content/en/blog/falco-wsl2-custom-kernel.md
@@ -67,9 +67,9 @@ cd
 # Source: https://github.com/microsoft/WSL2-Linux-Kernel/blob/7015d6023d60b29c3be4c6a398bed923b48b4341/README-Microsoft.WSL2
 sudo apt install -y build-essential flex bison libssl-dev libelf-dev
 
-# Get the latest stable Linux Kernel
+# Get the latest stable Linux Kernel, but only the latest version of each file and only the specific branch we want
 # git needs to be installed
-git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+git clone --depth 1 --branch linux-rolling-stable https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
 
 # Ensure the "stable" branch is the active one
 cd linux


### PR DESCRIPTION
As written, the whole Linux kernel history will be cloned locally.  For our purposes, we only need the latest file versions (--depth 1) and a particular branch (--branch linux-rolling-stable).  This will save local storage space and network I/O.  My ISP appears to have started throttling me heavily in the middle of my full clone of the whole Linux kernel history.

Signed-off-by: Karl Magdsick <karl@magdsick.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

This saves users time and space by only cloning the part of the Linux repository we need.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:
