### PR TITLE
Change CoreOS to Flatcar Linux

### DIFF
--- a/content/en/docs/getting-started/third-party/production.md
+++ b/content/en/docs/getting-started/third-party/production.md
@@ -4,16 +4,16 @@ description: Integrations built on the Falco core in a production environment
 weight: 3
 ---
 
-## CoreOS
+## Flatcar Linux
 
-The recommended way to run Falco on CoreOS is inside of its own Docker container using the install commands in the [Docker section](/docs/getting-started/running#docker). This method allows full visibility into all containers on the host OS.
+The recommended way to run Falco on Flatcar Linux is inside of its own Docker container using the install commands in the [Docker section](/docs/getting-started/running#docker). This method allows full visibility into all containers on the host OS.
 
-This method is automatically updated, includes some nice features such as automatic setup and bash completion, and is a generic approach that can be used on other distributions outside CoreOS as well.
+This method is automatically updated, includes some nice features such as automatic setup and bash completion, and is a generic approach that can be used on other distributions outside Flatcar Linux as well.
 
-However, some users may prefer to run Falco in the CoreOS toolbox. While not the recommended method, this can be achieved by installing Falco inside the toolbox using the normal installation method, and then manually running the `falco-driver-loader` script:
+However, some users may prefer to run Falco in the Flatcar Linux toolbox. While not the recommended method, this can be achieved by installing Falco inside the toolbox using the normal installation method, and then manually running the `falco-driver-loader` script:
 
 ```shell
-toolbox --bind=/dev --bind=/var/run/docker.sock
+toolbox 
 curl -s https://falco.org/script/install | bash
 falco-driver-loader
 ```


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

**What type of PR is this?**
/kind content
/area documentation

**What this PR does / why we need it:**
CoreOS the way we knew is deprecated :) The de-facto replacement is Flatcar Linux.

Also, I've removed the binding from toolbox, as it generates errors (toolbox already mounts everything)

As a followup, it would be good to remove the '-q' from yum install script, as this leaves anxious users (as me) wondering if something wrong happened, when it's just my internet that is slow :P