### PR TITLE
fix some typos for falcosidekick-reponse-engine-part-4-tekton blog post

### DIFF
--- a/content/en/blog/falcosidekick-reponse-engine-part-4-tekton.md
+++ b/content/en/blog/falcosidekick-reponse-engine-part-4-tekton.md
@@ -140,7 +140,7 @@ So how does all this work?
 
 - We start a random pod and perform a simple exec.
 - Falco will notice that a pod have broken the rule
-- Sends a event to Falcosidekick
+- Sends an event to Falcosidekick
 - Sends a webhook to tekton event-listener
 - Tekton triggers a new pipeline
 - A task is started with a small go program that deletes the pod
@@ -149,7 +149,7 @@ So lets look at some yaml.
 
 #### The go code
 
-I have adapted the code that Batuhan Apaydın wrote in [Falcosidekick + OpenFaas = a Kubernetes Response Engine, Part 2](https://falco.org/blog/falcosidekick-openfaas/) to listen for json in a environment variable instead of a http request.
+I have adapted the code that Batuhan Apaydın wrote in [Falcosidekick + OpenFaas = a Kubernetes Response Engine, Part 2](https://falco.org/blog/falcosidekick-openfaas/) to listen for json in an environment variable instead of a http request.
 
 Below you can see the code, in short it does the following:
 
@@ -376,6 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tekton-triggers-example-binding
+  namespace: falcoresponse
 subjects:
   - kind: ServiceAccount
     name: tekton-triggers-example-sa
@@ -533,7 +534,7 @@ And what parameter to send down to the pipeline, notice the **tt** in front of p
 The triggerTemplate was the final piece needed and you should see a pod spinning up in the falcoresponse namespace.
 
 ```shell
-kubectl get pdos -n falcoresponse
+kubectl get pods -n falcoresponse
 NAME                                                 READY   STATUS      RESTARTS   AGE
 el-falco-listener-557786f598-zdmw2                   1/1     Running     0          2h
 ```


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> /kind bug

**Any specific area of the project related to this PR?**

> /area documentation

**What this PR does / why we need it**:

I fixed some typos, and added necessary namespace information for RoleBinding to avoid an error like the following in for EventListener pod:

```bash
runtime/asm_amd64.s:1374: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:falcoresponse:tekton-triggers-example-sa" cannot list resource "configmaps" in API group "" in the namespace "falcoresponse"
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
