### PR TITLE
Update install script

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -163,7 +163,7 @@ archived_version = false
 version = "v0.29.0"
 
 # SHA256 checksum variable
-sha256sum = "21e8053c37e32f95d91c9393d961af1c63b5839d795c8cac314d05daadea9779"
+sha256sum = "711c2c19be846839a2e0bd9386adf3fd92933c99588ec05b75530d795c767c3c"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.

--- a/config.toml
+++ b/config.toml
@@ -163,7 +163,7 @@ archived_version = false
 version = "v0.29.0"
 
 # SHA256 checksum variable
-sha256sum = "711c2c19be846839a2e0bd9386adf3fd92933c99588ec05b75530d795c767c3c"
+sha256sum = "59201c1339cc53e86edcd7d2e7273e52f784b3cf7d4a3142059112b3b9062f6d"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.

--- a/static/script/install
+++ b/static/script/install
@@ -19,8 +19,8 @@ function install_rpm {
 		echo "* Installing curl"
 		yum -q -y install curl
 	fi
-
-	if ! yum -q list dkms > /dev/null 2>&1; then
+	
+	if ! rpm -qa | grep epel > /dev/null 2>&1; then
 		echo "* Installing EPEL repository (for DKMS)"
 		if [ "$VERSION" -eq 8 ]; then
 			rpm --quiet -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
@@ -30,7 +30,7 @@ function install_rpm {
 			rpm --quiet -i https://mirrors.kernel.org/fedora-epel/6/i386/epel-release-6-8.noarch.rpm
 		fi
 	fi
-
+	
 	echo "* Installing Falco public GPG key"
 	rpm --quiet --import https://falco.org/repo/falcosecurity-3672BA8F.asc
 	echo "* Installing Falco repository"
@@ -62,13 +62,38 @@ function install_deb {
 	echo "* Installing Falco public GPG key"
 	curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add -
 	echo "* Installing Falco repository"
-	echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+	echo "deb https://download.falco.org/packages/deb stable main" | tee /etc/apt/sources.list.d/falcosecurity.list
 	apt-get -qq update < /dev/null
 	echo "* Installing kernel headers"
 	apt-get -qq -y install "linux-headers-$(uname -r)" < /dev/null || kernel_warning
 	echo "* Installing Falco"
 	apt-get -qq -y install falco < /dev/null
 }
+
+function install_suse {
+	if ! hash curl > /dev/null 2>&1; then
+		echo "* Installing curl"
+		zypper -q -n install curl
+	fi
+	
+	rpm --import https://falco.org/repo/falcosecurity-3672BA8F.asc
+	curl -s -o /etc/zypp/repos.d/falcosecurity.repo https://falco.org/repo/falcosecurity-rpm.repo
+	
+	KERNEL_VERSION=$(uname -r)
+	if [[ $KERNEL_VERSION == *PAE* ]]; then
+		zypper -q -n install "kernel-PAE-devel-${KERNEL_VERSION%.PAE}" || kernel_warning
+	elif [[ $KERNEL_VERSION == *stab* ]]; then
+		# It's OpenVZ kernel and we should install another package
+		zypper -q -n install "vzkernel-devel-$KERNEL_VERSION" || kernel_warning
+	elif [[ $KERNEL_VERSION == *uek* ]]; then
+		zypper -q -n install "kernel-uek-devel-$KERNEL_VERSION" || kernel_warning
+	else
+		zypper -q -n install kernel-default-devel || kernel_warning
+	fi
+	echo "* Installing Falco"
+	zypper -q -n install falco
+}
+
 
 function unsupported {
 	echo 'Unsupported operating system. Please consider writing to the mailing list at'
@@ -188,9 +213,8 @@ elif [ -f /etc/system-release-cpe ]; then
 			;;
 
 	esac
-
+elif [ -z $(cat /etc/os-release  | grep ^SUSE) ]; then
+	install_suse
 else
 	unsupported
 fi
-
-modprobe -r falco_probe


### PR DESCRIPTION
### Changes
- The script will install epel if not present
- The script will support Suse
- mobprobe command removed
- override instead of append to `falcosecurity.list` file.

### NOT in the script
I think that from version 0.28 a reload of the systemd manager configuration is needed.

### Notes
Except for Suse (which we tested in our test environment, on different version of Suse) we used the script a lot without any issues.

**Special notes for your reviewer**:
Thanks for your time :)


/cc @leodido 
/cc @leogr 

/kind content
/area documentation

Signed-off-by: Domenico Chirabino