### PR TITLE
Add systemd manager configuration command

### DIFF
--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -47,12 +47,17 @@ Alternatively, it is also possible to use a binary package as [explained below](
     apt-get install -y falco
     ```
 
+4. Reload systemd manager configuration
+   ```shell
+   systemctl daemon-reload
+   ```
+
     Falco, the kernel module driver, and a default configuration are now installed.
     Falco is being ran as a systemd unit.
 
     See [running](../running) for information on how to manage, run, and debug with Falco.
 
-4. Uninstall Falco:
+5. Uninstall Falco:
 
     ```shell
     apt-get remove falco
@@ -82,13 +87,20 @@ Alternatively, it is also possible to use a binary package as [explained below](
     ```shell
     yum -y install falco
     ```
+    
+4. Reload systemd manager configuration
+   ```shell
+   systemctl daemon-reload
+   ```
+   
     Falco, the kernel module driver, and a default configuration are now installed.
     Falco is being ran as a systemd unit.
 
     See [running](../running) for information on how to manage, run, and debug with Falco.
 
 
-4. Uninstall Falco:
+
+5. Uninstall Falco:
 
     ```shell
     yum erase falco
@@ -114,13 +126,18 @@ Alternatively, it is also possible to use a binary package as [explained below](
     ```shell
     zypper -n install falco
     ```
+
+4. Reload systemd manager configuration
+   ```shell
+   systemctl daemon-reload
+   ```
     Falco, the kernel module driver, and a default configuration are now installed.
     Falco is being ran as a systemd unit.
 
     See [running](../running) for information on how to manage, run, and debug with Falco.
 
 
-4. Uninstall Falco:
+5. Uninstall Falco:
 
     ```shell
     zypper rm falco


### PR DESCRIPTION
Signed-off-by: Domenico Chirabino <chirabino@protonmail.com>

Add reload systemd manager configuration command

/kind content
/area documentation


**What this PR does / why we need it**:
After installation we need to reload the systemd manager so that the new unit is loaded.

**Which issue(s) this PR fixes**:
#467 (as asked in [this comment](https://github.com/falcosecurity/falco-website/pull/467#issuecomment-870594970)

/assign @leogr 
