### PR TITLE
Docs: fix openSUSE install instructions

### DIFF
--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -106,8 +106,10 @@ Alternatively, it is also possible to use a binary package as [explained below](
 2. Install kernel headers:
 
     ```shell
-    zypper -n install kernel-default-devel
+    zypper -n install kernel-default-devel-$(uname -r | sed s/\-default//g)
     ```
+
+    > **Note** — If the package was not found by the above command, you might need to run `zypper -n dist-upgrade` in order to fix it. Rebooting the system may be required.
 
 3. Install Falco:
 


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

**What type of PR is this?**
/kind content

**Any specific area of the project related to this PR?**
/area documentation

**What this PR does / why we need it**:
Our openSUSE installation steps have users install `kernel-default-devel`. This PR changes it to `kernel-devel-$(uname -r)` and provides some guidance on how to solve cases in which a package might have been removed from the upstream repo (like it's already being done for other distros in the same document - see CentOS as a reference).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
