### PR TITLE
fix link to Falco with helm

### DIFF
--- a/content/en/docs/getting-started/third-party/production.md
+++ b/content/en/docs/getting-started/third-party/production.md
@@ -55,7 +55,7 @@ to the file:
 Environment='FALCO_BPF_PROBE=""'
 ```
 
-If you are [installing Falco with Helm](https://falco.org/docs/third-party/#helm), you will need to set the `ebpf.enabled` option to `true`:
+If you are [installing Falco with Helm](https://falco.org/docs/getting-started/third-party/install-tools/#helm), you will need to set the `ebpf.enabled` option to `true`:
 
 ```
 helm install falco falcosecurity/falco --set ebpf.enabled=true


### PR DESCRIPTION
Signed-off-by: ramshazar <1233515+ramshazar@users.noreply.github.com>

**What type of PR is this?**

/kind cleanup
/kind documentation

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

There is a link on https://falco.org/docs/getting-started/third-party/production/#gke that is an 404.
The PR provides the correct link.