### PR TITLE
Enable falco service

### DIFF
--- a/content/en/docs/getting-started/running.md
+++ b/content/en/docs/getting-started/running.md
@@ -9,6 +9,11 @@ weight: 4
 
 If you installed Falco by using [the DEB or the RPM](/docs/getting-started/installation) package, you can start the service by running:
 
+
+```console
+systemctl enable falco
+```
+
 ```console
 systemctl start falco
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:
On Ubuntu 18.04.6 LTS, After installation, I had to enable the `falco` service first and then I could start it.

Otherwise, I was getting error: 
```
Failed to start falco.service: Unit falco.service not found
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

