### PR TITLE
[rule_enable_opt] remove reference to bug in docs

### DIFF
--- a/content/en/docs/rules/_index.md
+++ b/content/en/docs/rules/_index.md
@@ -276,16 +276,6 @@ For example to disable the `User mgmt binaries` default rule in `/etc/falco/falc
 ```
 
 
- {{% pageinfo color="warning" %}}
- There appears to be a bug with this feature that we are looking into. If `enabled: false` doesn't work, you can use the following workaround as an alternative:
- ```yaml
- - rule: User mgmt binaries
-   condition: and (never_true)
-   append: true
- ```
- {{% /pageinfo %}}
-
-
 ## Output
 
 A rule output is a string that can use the same [fields](/docs/rules/supported-fields) that conditions can use prepended by `%` to perform interpolation, akin to `printf`. For example:


### PR DESCRIPTION
Signed-off-by: pablopez <pablo.lopezzaldivar@sysdig.com>

**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

During the last community call. @jasondellaluce mentioned that the bug impacting the `enable` field of falco rules will be addressed in the next release. So, this note in the docs won't be required any more.

**Which issue(s) this PR fixes**:

None that I am aware of, but it might be of interest in https://github.com/falcosecurity/falco/issues/1857
