### PR TITLE
fix: typo in the running and plugin dev-guide sections

### DIFF
--- a/content/en/docs/getting-started/running.md
+++ b/content/en/docs/getting-started/running.md
@@ -34,7 +34,7 @@ falco --help
 
 {{% pageinfo color="primary" %}}
 
-Are you looking for userpace instrumentation? Please see [this page](/docs/event-sources/drivers/).
+Are you looking for userspace instrumentation? Please see [this page](/docs/event-sources/drivers/).
 
 {{% /pageinfo %}}
 

--- a/content/en/docs/plugins/developers-guide.md
+++ b/content/en/docs/plugins/developers-guide.md
@@ -655,7 +655,7 @@ func (m *MyPlugin) Fields() []sdk.FieldEntry {
 
 #### Extracting Fields
 
-The `Extractor` method extracts any of the supported fields. The `req` parameter allows accessing all the info regarding the field request, such as the field id or name, and the optional user-passed argument. The `evt` parameter is an interface that halps reading the event info and data.
+The `Extractor` method extracts any of the supported fields. The `req` parameter allows accessing all the info regarding the field request, such as the field id or name, and the optional user-passed argument. The `evt` parameter is an interface that helps reading the event info and data.
 
 The extracted field value must be set through the `SetValue` method of `sdk.ExtractRequest`. Returning from `Extract` without calling `SetValue` will signal the SDK that the requested field is not present in the given event.
 


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

Typo in the `getting-started/running`  and  `/plugins/developers-guide` sections.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

