### PR TITLE
fix: Probably deprecated syntax

### DIFF
--- a/content/en/docs/examples.md
+++ b/content/en/docs/examples.md
@@ -59,7 +59,7 @@ For a more comprehensive set of examples, see the full rules file at `falco_rule
 
 - rule: write_binary_dir
   desc: an attempt to write to any file below a set of binary directories
-  condition: evt.dir = < and open_write and not package_mgmt_binaries and bin_dir
+  condition: evt.dir = < and open_write and not evt.dir in (package_mgmt_binaries) and bin_dir
   output: "File below a known binary directory opened for writing (user=%user.name command=%proc.cmdline file=%fd.name)"
   priority: WARNING
 ```


### PR DESCRIPTION
Signed-off-by: rachejazz <divyadeepti2000@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> /kind bug

**Any specific area of the project related to this PR?**

> /area documentation

**Special notes for your reviewer**:
The previous rule syntax gave the following error in pod logs:
```
Compilation error when compiling "evt.dir = < and open_write and not dnf, rpm, rpmkey, yum, "75-system-updat", rhsmcertd-worke, rhsmcertd, subscription-ma, repoquery, rpmkeys, rpmq, yum-cron, yum-config-mana, yum-debug-dump, abrt-action-sav, rpmdb_stat, microdnf, rhn_check, yumdb, dpkg, dpkg-preconfigu, dpkg-reconfigur, dpkg-divert, apt, apt-get, aptitude, frontend, preinst, add-apt-reposit, apt-auto-remova, apt-key, apt-listchanges, unattended-upgr, apt-add-reposit, apt-cache, apt.systemd.dai, update-alternat, gem, pip, pip3, sane-utils.post, alternatives, chef-client, apk, snapd and bin_dir": 39: syntax error, unexpected ',', expecting 'or', 'and'
```
Because `package_mgmt_binaries` is a list. By adding the `in` with the `evt.dir` explicitly accessing each element in the array, the error gets solved