### PR TITLE
docs(content): ncurses is not required anymore

### DIFF
--- a/content/en/docs/getting-started/source.md
+++ b/content/en/docs/getting-started/source.md
@@ -14,7 +14,7 @@ doing all this, chances that you are willing to contribute are high! Please read
 CentOS 7 / RHEL 7
 
 ```bash
-yum install gcc gcc-c++ git make autoconf automake pkg-config patch ncurses-devel libtool glibc-static libstdc++-static elfutils-libelf-devel
+yum install gcc gcc-c++ git make autoconf automake pkg-config patch libtool glibc-static libstdc++-static elfutils-libelf-devel
 ```
 
 You will also need `cmake` version `3.5.1` or higher which is not included in CentOS 7. You can follow the [official guide](https://cmake.org/install/) or look at how that is done in the [Falco builder Dockerfile](https://github.com/falcosecurity/falco/blob/master/docker/builder/Dockerfile).
@@ -22,20 +22,20 @@ You will also need `cmake` version `3.5.1` or higher which is not included in Ce
 CentOS 8 / RHEL 8
 
 ```bash
-dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch ncurses-devel libtool elfutils-libelf-devel diffutils which
+dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch libtool elfutils-libelf-devel diffutils which
 ```
 {{< /tab >}}}
 
 {{% tab name="Debian/ Ubuntu" %}}
 ```bash
-apt install git cmake build-essential libncurses-dev pkg-config autoconf libtool libelf-dev -y
+apt install git cmake build-essential pkg-config autoconf libtool libelf-dev -y
 ```
 {{< /tab >}}}
 
 {{% tab name="Arch Linux" %}}
 ```bash
 pacman -S git cmake make gcc wget
-pacman -S zlib jq ncurses yaml-cpp openssl curl c-ares protobuf grpc libyaml
+pacman -S zlib jq yaml-cpp openssl curl c-ares protobuf grpc libyaml
 ```
 
 You'll also need kernel headers for building and making binaries properly.
@@ -52,13 +52,13 @@ Since Alpine ships with `musl` instead of `glibc`, to build on Alpine, we need t
 If that option is used along with the `-DUSE_BUNDLED_DEPS=On` option, then the final build will be 100% statically-linked and portable across different Linux distributions.
 
 ```bash
-apk add g++ gcc cmake cmake make ncurses-dev git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
+apk add g++ gcc cmake cmake make git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
 ```
 {{< /tab >}}}
 
 {{% tab name="openSUSE" %}}
 ```bash
-zypper -n install gcc gcc-c++ git-core cmake libjq-devel ncurses-devel yaml-cpp-devel libopenssl-devel libcurl-devel c-ares-devel protobuf-devel grpc-devel patch which automake autoconf libtool libelf-devel libyaml-devel
+zypper -n install gcc gcc-c++ git-core cmake libjq-devel yaml-cpp-devel libopenssl-devel libcurl-devel c-ares-devel protobuf-devel grpc-devel patch which automake autoconf libtool libelf-devel libyaml-devel
 ```
 {{< /tab >}}}
 {{< /tabs >}}
@@ -286,7 +286,6 @@ For the sake of completeness this is the complete list of Falco dependencies:
 - lpeg
 - luajit
 - lyaml
-- ncurses
 - njson
 - openssl
 - protobuf

--- a/content/ja/docs/getting-started/source.md
+++ b/content/ja/docs/getting-started/source.md
@@ -18,14 +18,14 @@ CentOS 7は、リリースアーティファクトのコンパイルに使用す
 dnf install 'dnf-command(config-manager)'
 dnf config-manager --set-enabled PowerTools # needed for libyaml-devel
 dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch
-dnf install libcurl-devel zlib-devel libyaml-devel ncurses-devel libtool glibc-static libstdc++-static elfutils-libelf-devel -y
+dnf install libcurl-devel zlib-devel libyaml-devel libtool glibc-static libstdc++-static elfutils-libelf-devel -y
 ```
 
 **CentOS 7 / RHEL 7**
 
 ```
 yum install gcc gcc-c++ git make autoconf automake pkg-config patch
-yum install libcurl-devel zlib-devel libyaml-devel ncurses-devel libtool glibc-static libstdc++-static elfutils-libelf-devel -y
+yum install libcurl-devel zlib-devel libyaml-devel libtool glibc-static libstdc++-static elfutils-libelf-devel -y
 ```
 
 You will also need `cmake` version `3.5.1` or higher which is not included in CentOS 7. You can follow the [official guide](https://cmake.org/install/) or look at how that is done
@@ -87,7 +87,7 @@ apt install git cmake build-essential
 ### Falcoのビルド
 
 ```bash
-apt install libssl-dev libyaml-dev libncurses-dev libc-ares-dev libprotobuf-dev protobuf-compiler libjq-dev libyaml-cpp-dev libgrpc++-dev protobuf-compiler-grpc libcurl4-openssl-dev libelf-dev
+apt install libssl-dev libyaml-dev libc-ares-dev libprotobuf-dev protobuf-compiler libjq-dev libyaml-cpp-dev libgrpc++-dev protobuf-compiler-grpc libcurl4-openssl-dev libelf-dev
 ```
 
 ```bash
@@ -133,7 +133,7 @@ make bpf
 
 ```bash
 pacman -S git cmake make gcc wget
-pacman -S zlib jq ncurses yaml-cpp openssl curl c-ares protobuf grpc libyaml
+pacman -S zlib jq yaml-cpp openssl curl c-ares protobuf grpc libyaml
 ```
 
 ### Falcoのビルド
@@ -189,7 +189,6 @@ make bpf
 - lpeg
 - luajit
 - lyaml
-- ncurses
 - njson
 - openssl
 - protobuf

--- a/content/ko/docs/source.md
+++ b/content/ko/docs/source.md
@@ -15,13 +15,13 @@ CentOS 7은 릴리스 아티팩트를 컴파일하는데 사용하는 레퍼런�
 **CentOS 8 / RHEL 8**
 
 ```bash
-dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch ncurses-devel libtool elfutils-libelf-devel diffutils which
+dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch libtool elfutils-libelf-devel diffutils which
 ```
 
 **CentOS 7 / RHEL 7**
 
 ```
-yum install gcc gcc-c++ git make autoconf automake pkg-config patch ncurses-devel libtool glibc-static libstdc++-static elfutils-libelf-devel
+yum install gcc gcc-c++ git make autoconf automake pkg-config patch libtool glibc-static libstdc++-static elfutils-libelf-devel
 ```
 
 CentOS 7에 포함되지 않은 `cmake` 버전 `3.5.1` 이상도 필요하다. [공식 가이드](https://cmake.org/install/)를 따르거나
@@ -76,7 +76,7 @@ make package
 ### 의존성 패키지
 
 ```bash
-apt install git cmake build-essential libncurses-dev pkg-config autoconf libtool libelf-dev -y
+apt install git cmake build-essential pkg-config autoconf libtool libelf-dev -y
 ```
 
 ### 팔코 빌드
@@ -132,7 +132,7 @@ make bpf
 
 ```bash
 pacman -S git cmake make gcc wget
-pacman -S zlib jq ncurses yaml-cpp openssl curl c-ares protobuf grpc libyaml
+pacman -S zlib jq yaml-cpp openssl curl c-ares protobuf grpc libyaml
 ```
 
 ### 팔코 빌드
@@ -177,7 +177,7 @@ Alpine이 `glibc` 대신 `musl` 을 제공하기 때문에, Alpine에서 빌드�
 ### 의존성 패키지
 
 ```bash
-apk add g++ gcc cmake cmake make ncurses-dev git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
+apk add g++ gcc cmake cmake make git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
 ```
 
 ### 팔코 빌드
@@ -196,7 +196,7 @@ make falco
 ### 의존성 패키지
 
 ```bash
-zypper -n install gcc gcc-c++ git-core cmake libjq-devel ncurses-devel yaml-cpp-devel libopenssl-devel libcurl-devel c-ares-devel protobuf-devel grpc-devel patch which automake autoconf libtool libelf-devel
+zypper -n install gcc gcc-c++ git-core cmake libjq-devel yaml-cpp-devel libopenssl-devel libcurl-devel c-ares-devel protobuf-devel grpc-devel patch which automake autoconf libtool libelf-devel
 ```
 
 ### 팔코 빌드
@@ -253,7 +253,6 @@ make bpf
 - lpeg
 - luajit
 - lyaml
-- ncurses
 - njson
 - openssl
 - protobuf

--- a/content/ml/docs/getting-started/source.md
+++ b/content/ml/docs/getting-started/source.md
@@ -13,7 +13,7 @@ weight: 5
 CentOS 7 / RHEL 7
 
 ```bash
-yum install gcc gcc-c++ git make autoconf automake pkg-config patch ncurses-devel libtool glibc-static libstdc++-static elfutils-libelf-devel
+yum install gcc gcc-c++ git make autoconf automake pkg-config patch libtool glibc-static libstdc++-static elfutils-libelf-devel
 ```
 
 CentOS 7 ൽ ഉൾപ്പെടുത്തിയിട്ടില്ലാത്തതിനാൽ  `cmake` ` 3.5.1`-ഓ  ഉയർന്നതോ ആയ പതിപ്പ്  നിങ്ങൾക്ക് ആവശ്യമാണ്. നിങ്ങൾക്ക് ഔദ്യോഗിക ഗൈഡ് [official guide](https://cmake.org/install/) പിന്തുടരാം. അല്ലെങ്കിൽ ഫാൽകോ ബിൽഡർ ഡോക്കർ ഫയലിൽ [Falco builder Dockerfile](https://github.com/falcosecurity/falco/blob/master/docker/builder/Dockerfile) ഇത് എങ്ങനെ ചെയ്യാമെന്ന് നോക്കാം.
@@ -21,20 +21,20 @@ CentOS 7 ൽ ഉൾപ്പെടുത്തിയിട്ടില്ലാ�
 CentOS 8 / RHEL 8
 
 ```bash
-dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch ncurses-devel libtool elfutils-libelf-devel diffutils which
+dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch libtool elfutils-libelf-devel diffutils which
 ```
 {{< /tab >}}}
 
 {{% tab name="Debian/ Ubuntu" %}}
 ```bash
-apt install git cmake build-essential libncurses-dev pkg-config autoconf libtool libelf-dev -y
+apt install git cmake build-essential pkg-config autoconf libtool libelf-dev -y
 ```
 {{< /tab >}}}
 
 {{% tab name="Arch Linux" %}}
 ```bash
 pacman -S git cmake make gcc wget
-pacman -S zlib jq ncurses yaml-cpp openssl curl c-ares protobuf grpc libyaml
+pacman -S zlib jq yaml-cpp openssl curl c-ares protobuf grpc libyaml
 ```
 {{< /tab >}}}
 
@@ -45,13 +45,13 @@ pacman -S zlib jq ncurses yaml-cpp openssl curl c-ares protobuf grpc libyaml
 
 
 ```bash
-apk add g++ gcc cmake cmake make ncurses-dev git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
+apk add g++ gcc cmake cmake make git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
 ```
 {{< /tab >}}}
 
 {{% tab name="openSUSE" %}}
 ```bash
-zypper -n install gcc gcc-c++ git-core cmake libjq-devel ncurses-devel yaml-cpp-devel libopenssl-devel libcurl-devel c-ares-devel protobuf-devel grpc-devel patch which automake autoconf libtool libelf-devel libyaml-devel
+zypper -n install gcc gcc-c++ git-core cmake libjq-devel yaml-cpp-devel libopenssl-devel libcurl-devel c-ares-devel protobuf-devel grpc-devel patch which automake autoconf libtool libelf-devel libyaml-devel
 ```
 {{< /tab >}}}
 {{< /tabs >}}
@@ -279,7 +279,6 @@ make bpf
 - lpeg
 - luajit
 - lyaml
-- ncurses
 - njson
 - openssl
 - protobuf


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

Since Falco 0.30.0, `ncurses` is not required anymore.
See https://github.com/falcosecurity/falco/pull/1658

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
