### PR TITLE
docs(content): improve doc on Falco least privileged with Docker container

### DIFF
--- a/content/en/docs/getting-started/running.md
+++ b/content/en/docs/getting-started/running.md
@@ -57,19 +57,6 @@ The images can be used in two ways as follows:
 
 ### Least privileged (recommended) {#docker-least-privileged}
 
-
-
-{{% pageinfo color="primary" %}}
-
-You cannot use the Least privileged mode with the eBPF probe driver unless you have at least Kernel 5.8,
-this is because `--privileged` is needed to do the `bpf` syscall.
-If you are running Kernel >= 5.8 you can pass `--cap-add BPF` to the docker run command in the step 2
-and ignore the Install the kernel module section completely.
-
-You can read more details about this [here](https://github.com/falcosecurity/falco/issues/1299#issuecomment-653448207)
-
-{{% /pageinfo %}}
-
 This is how the Falco userspace process can be ran in a container.
 
 Once the kernel module has been installed directly on the host system, it can be used from within a container.
@@ -128,6 +115,44 @@ Note that `ls /dev/falco* | xargs -I {} echo --device {}` outputs a `--device /d
 
 {{% /pageinfo %}}
 
+To run Falco in least privileged mode with the eBPF driver, we list all the required capabilities: 
+- on kernels <5.8, Falco requires `CAP_SYS_ADMIN`, `CAP_SYS_RESOURCE` and `CAP_SYS_PTRACE`
+- on kernels >=5.8, `CAP_BPF` and `CAP_PERFMON` were separated out of `CAP_SYS_ADMIN`, so the required capabilities are `CAP_BPF`, `CAP_PERFMON`, `CAP_SYS_RESOURCE`, `CAP_SYS_PTRACE`. Unfortunately, Docker does not yet support adding the two newly introduced capabilities with the `--cap-add` option. For this reason, we continue using `CAP_SYS_ADMIN`, given that it still allows performing the same operations granted by `CAP_BPF` and `CAP_PERFMON`. In the near future, Docker will support adding these two capabilities and we will be able to replace `CAP_SYS_ADMIN`.
+
+1. Install the eBPF probe
+    ```shell
+    docker pull falcosecurity/falco-driver-loader:latest
+    docker run --rm -i -t \
+        --privileged \
+        -v /root/.falco:/root/.falco \
+        -v /proc:/host/proc:ro \
+        -v /boot:/host/boot:ro \
+        -v /lib/modules:/host/lib/modules:ro \
+        -v /usr:/host/usr:ro \
+        -v /etc:/host/etc:ro \
+        falcosecurity/falco-driver-loader:latest bpf
+    ```
+2. Then, run Falco
+    ```shell
+    docker pull falcosecurity/falco-no-driver:latest
+    docker run --rm -i -t \
+        --cap-drop all \
+        --cap-add sys_admin \
+        --cap-add sys_resource \
+        --cap-add sys_ptrace \
+        -v /var/run/docker.sock:/host/var/run/docker.sock \
+        -e FALCO_BPF_PROBE="" \
+        -v /root/.falco:/root/.falco \
+        -v /etc:/host/etc \
+        -v /proc:/host/proc:ro \
+        falcosecurity/falco-no-driver:latest
+    ```
+
+{{% pageinfo color="warning" %}}
+
+Again, you will need to add `--security-opt apparmor:unconfined` to the last command if your system has the AppArmor LSM enabled. 
+
+{{% /pageinfo %}}
 ### Fully privileged {#docker-privileged}
 
 To run Falco in a container using Docker with full privileges use the following commands.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

This PR tries to better describe how Falco can be run according to the least privileged principle. 

First, I removed the note stating that `--privileged` is required for Falco and eBPF. This is true in part. To be precise, on kernel versions <5.8 the `CAP_SYS_ADMIN` capability is required to perform the `bpf` syscall. The `--privileged` flag adds this capability under the hood, and that's why it works. However, that flag turns off many other security-related options, giving the process running in the container many ways to interact with the host, as if it were a normal process. As per the least privilege principle, it is better to only add `CAP_SYS_ADMIN`. 

The solution with `CAP_SYS_ADMIN` is a simple one-liner that should work in any kernel version, and it is strictly required on kernel  <5.8. On kernel >5.8, the minimal set of required capabilities is `CAP_BPF`, `CAP_PERFMON`, `CAP_SYS_RESOURCE`, `CAP_SYS_PTRACE` and `CAP_SYS_ADMIN` is no longer needed. Unfortunately, depending on docker and runc, `CAP_BPF`, `CAP_PERFMON` will be ready to use in the near future. When they will be used, we will complete the transition to running Falco least privileged also in these newer kernel versions. Until that moment, we stick with  `CAP_SYS_ADMIN`, given that this capability still allows performing the operations granted by the newer `CAP_BPF`, `CAP_PERFMON`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

In the following, I am trying to better explain why each capability is needed.

To use the eBPF driver, Falco needs to be able to use the `bpf` syscall to load eBPF programs and create maps, and to open  per-cpu ring buffers, which is done via the `perf` subsytem. Before kernel 5.8, the ability to perform these operations was bundled together under the `CAP_SYS_ADMIN` capability. To separate out BPF and perf functionalities from the overloaded `CAP_SYS_ADMIN` capability, the following two capabilities were introduced starting from kernel 5.8:

- `CAP_BPF`
- `CAP_PERFMON`

Other needed capabilities are:

- `CAP_SYS_RESOURCE`: Falco needs this to call the `setrlimit` syscall. This syscall is used together with `RLIMIT_MEMLOCK` flag. Usually, this flag is used to set the amount of memory that can be mlocked into RAM, preventing a possible swap out. On kernel <5.11, eBPF uses locked memory for maps and other things. The default memory limit value is very low, so even a very simple eBPF program will fail to load due to this. The workaround is to increase the default value to something acceptable so that maps and other stuff can be correctly mlocked in memory. After kernel 5.11 the accounting of memory for eBPF programs and maps is done via memory cgroups, so this capability is no more needed because there is no need to change that limit. You can dig deeper reading this [blog post](https://facebookmicrosites.github.io/bpf/blog/2020/02/20/bcc-to-libbpf-howto-guide.html#locked-memory-limits) and [patch]([/QMqHcyyOTCaengoSNEMK_A](https://lore.kernel.org/bpf/20201201215900.3569844-1-guro@fb.com/t/#u)).
- `CAP_SYS_PTRACE`: Falco needs this capability because it accesses fields like `environ` in the proc file system, when it constructs the "state of the world" at initialization. The `/proc/<pid>/environ` pseudo file operations will retrieve the memory descriptor of the target process to access its memory and retrieve the environment variables. From the userspace standpoint, the permission to do so is mapped to the `CAP_SYS_PTRACE` capability. For the curious reader, see [environ_open](https://elixir.bootlin.com/linux/latest/source/fs/proc/base.c#L937) and [environ_read]([/RxRcFcXYQVOG_PLdj_JGJA](https://elixir.bootlin.com/linux/latest/source/fs/proc/base.c#L942)) implementation in the kernel. 

Ultimately, `CAP_BPF`, `CAP_PERFMON`, `CAP_SYS_RESOURCE`, `CAP_SYS_PTRACE` should represent the minimum set of capabilities needed by Falco, but depending on the version of the container runtime of choice, `CAP_BPF` could not be correctly recognized. Unfortunately in this case, `CAP_SYS_ADMIN` is required instead.

I intend to write a blog post with this information soon and link it to the documentation