### PR TITLE
docs(content): add a new step in the upgrading phase

### DIFF
--- a/content/en/docs/getting-started/upgrade.md
+++ b/content/en/docs/getting-started/upgrade.md
@@ -8,6 +8,12 @@ This section provides upgrading paths for Falco if previously installed followin
 
 ## Upgrading
 
+According to the installation method you chose, you first have to remove the active kernel module before upgrading Falco to the latest version:
+
+```shell
+rmmod falco
+```
+
 ### Debian/Ubuntu {#debian}
 
 {{% pageinfo color="warning" %}}


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

When installing Falco with  `.deb`, `.rpm` or with the binary package, we have to remove the old kernel module injected in the kernel, before upgrading Falco. Otherwise, we will have errors like the following, due to driver versions incompatibility:

```
Runtime error: Kernel module does not support PPM_IOCTL_GET_API_VERSION. Exiting.
```
This happens with Falco `0.31.1` because we introduced a mechanism to detect incompatible driver versions. The simple command added here should solve issues with local package installations quoted here :point_down: 

https://github.com/falcosecurity/falco/issues/1941#issuecomment-1068976133

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
