### PR TITLE
Add cloudtrail event source page

### DIFF
--- a/content/en/docs/event-sources/_index.md
+++ b/content/en/docs/event-sources/_index.md
@@ -3,8 +3,15 @@ title: Event Sources
 weight: 5
 ---
 
-Falco can consume events from different sources, and apply rules to these events to detect abnormal behavior. Currently Falco supports the following event sources:
+Falco can consume events from a variety of different sources and apply rules to these events to detect abnormal behavior.
+
+Currently, Falco supports the following built-in event sources:
 
 * System Calls (syscall) via the [drivers](./drivers)
 * [Kubernetes Audit Events](./kubernetes-audit) (k8s_audit)
 
+Falco also supports the following event sources via officially supported [plugins](../plugins):
+
+* [AWS Cloudtrail](./cloudtrail)
+
+In addition to these event sources, others have written third-party [plugins](https://github.com/falcosecurity/plugins#readme) that support additional event sources.

--- a/content/en/docs/event-sources/_index.md
+++ b/content/en/docs/event-sources/_index.md
@@ -13,5 +13,6 @@ Currently, Falco supports the following built-in event sources:
 Falco also supports the following event sources via officially supported [plugins](../plugins):
 
 * [AWS Cloudtrail](./cloudtrail)
+* [Okta](./okta)
 
 In addition to these event sources, others have written third-party [plugins](https://github.com/falcosecurity/plugins#readme) that support additional event sources.

--- a/content/en/docs/event-sources/cloudtrail.md
+++ b/content/en/docs/event-sources/cloudtrail.md
@@ -1,0 +1,34 @@
+---
+title: Cloudtrail Events
+weight: 2
+---
+
+The Falco [Cloudtrail](https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail#readme) plugin can read [AWS Cloudtrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html) logs and emit events for each Cloudtrail log entry.
+
+Falco also distributes out-of-the-box [rules](https://github.com/falcosecurity/falco/blob/master/rules/aws_cloudtrail_rules.yaml) that can be used to identify interesting/suspicious/notable events in Cloudtrail logs, including:
+
+* Console logins that do not use multi-factor authentication
+* Disabling multi-factor authentication for users
+* Disabling encryption for S3 buckets.
+
+# Configuration
+
+See the [README](https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail#configuration) for information on how to configure the plugin. The plugin initialization and open params strings/objects can be added to `falco.yaml` under the `plugins` [configuration key](https://falco.org/docs/configuration/) key.
+
+# Ways to read Cloudtrail Logs
+
+The plugin can be configured to read log files from:
+
+* A S3 bucket
+* A SQS queue that passes along SNS notifications about new log files
+* A local filesystem path
+
+For more information on the open params syntax, see [open params](https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail#plugin-open-params).
+
+# Terraform Module For Cloudtrail Prerequsites
+
+In order to use the Cloutrail plugin, you must [enable](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-cloudtrail-logging-for-s3.html) Cloudtrail logging for the account(s) you want to monitor. This must be done before using the plugin.
+
+In addition, of the three options above, using an SQS queue provides the easiest-to-consume source of logs. With the SQS queue, the plugin can detect when the new log files are written and can automatically consume them. However, this also requires creating multiple AWS cloud resources, such as SQS queues, SNS topics/subscriptions, IAM policy documents, etc., outside of Falco, which involve multiple manual steps.
+
+To make this process easier, we've created a Terraform [module](https://github.com/falcosecurity/falco-cloudtrail-terraform) that automatically creates these resources.

--- a/content/en/docs/event-sources/okta.md
+++ b/content/en/docs/event-sources/okta.md
@@ -1,0 +1,40 @@
+---
+title: Okta Events
+weight: 2
+---
+
+The Falco [Okta](https://github.com/falcosecurity/plugins/blob/master/plugins/okta/README.md) plugin can read [Okta](https://www.okta.com/) logs and emit events for each Okta log entry.
+
+Falco also distributes out-of-the-box [rules](https://github.com/falcosecurity/falco/blob/master/rules/okta_rules.yaml) that can be used to identify interesting/suspicious/notable events in Okta logs, including:
+
+* Creating a new OKTA user account
+* Detecting a locked-out user
+* Assigning admin permissions to an okta user
+
+# Configuration
+
+See the [README](https://github.com/falcosecurity/plugins/blob/master/plugins/okta/README.md#settings) for information on configuring the plugin. This simply involves providing the `organization/api` token as part of init params. These can be added to `falco.yaml` under the `plugins` [configuration key](https://falco.org/docs/configuration/) key.
+
+The plugin does not use any open params configuration.
+
+# Sample Output
+
+For example, when using a dummy rule as follows:
+
+```
+- rule: Dummy
+  desc: Dummy
+  condition: okta.app!=""
+  output: "evt=%okta.evt.type user=%okta.actor.name ip=%okta.client.ip app=%okta.app"
+  priority: DEBUG
+  source: okta
+  tags: [okta]
+```
+
+The dummy rule will emit an alert for each Okta log entry, like the following:
+
+```
+19:12:25.439350000: Debug evt=user.authentication.sso user=User1 ip=x.x.x.x app=google
+19:12:30.675628000: Debug evt=user.authentication.sso user=User2 ip=x.x.x.x app=github
+19:12:35.918456000: Debug evt=user.authentication.sso user=User3 ip=x.x.x.x app=office365
+```


### PR DESCRIPTION
It mostly points to other repos/readmes/etc for the details on how to
use Cloudtrail with falco, but we didn't really have a docs page about
Cloudtrail other than inside the plugins section, which is too much
detail for someone just trying to get cloudtrail to work.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
