### PR TITLE
docs: add stdout buffering explanation

### DIFF
--- a/content/en/docs/alerts/_index.md
+++ b/content/en/docs/alerts/_index.md
@@ -30,6 +30,12 @@ Standard output is useful when using Fluentd or Logstash to capture logs from co
 
 When run in the background via the `-d/--daemon` command line option, standard output messages are discarded.
 
+### Standard Output buffering
+
+If the logs are inspected by tailing container logs (e.g. `kubectl logs -f` in Kubernetes) it might look like events can take a long time to appear, sometimes more than 15 minutes.
+This is not an issue with Falco but is simply a side effect of the system output buffering. However, if realtime update of these logs is necessary it can be forced
+with the `-U/--unbuffered` command line option which will ensure the output is flushed for every event at the cost of higher CPU usage.
+
 ## File Output
 
 When configured to send alerts to a file, a message is written to the file for each alert. The format is very similar to the Standard Output format:


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

Add more explicit documentation on the behavior of the `-U/--unbuffered` option.
I think we need more documentation on that because in some clusters events might take a long time to appear in `kubectl logs -f` because of log output buffering. Although that is not the way people use to get falco logs in production it is the way some of us use to check if Falco is working, to do debugging, or for training scenarios. If you don't know about buffering that looks like a Falco bug (while it isn't) and sometimes issues are opened for that ( e.g. https://github.com/falcosecurity/falco/issues/1957 )

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
