### PR TITLE
fix: updating eBPF probe minimum kernel version guidance

### DIFF
--- a/content/en/blog/choosing-a-driver.md
+++ b/content/en/blog/choosing-a-driver.md
@@ -120,7 +120,7 @@ sudo falco
 #### Cons
 
  - The eBPF probe does not work for every system.
- - You need at least Linux kernel version 4.4 or, preferably, 4.9 to run eBPF. The Falco project suggests a LTS 4.14/4.19 or above.
+ - You need at least Linux kernel version 4.14 but the Falco project suggests an LTS kernel of 4.14/4.19 or above.
 
 #### Summary 
 


### PR DESCRIPTION
/kind cleanup

**Any specific area of the project related to this PR?**

/area blog

**What this PR does / why we need it**:
Updates minimum kernel version guidance to be 4.14. As per https://github.com/falcosecurity/libs/blob/master/driver/bpf/quirks.h#L14-L16 4.14 is the minimum kernel version