### PR TITLE
[training-page] add detail for specific courses

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -3,6 +3,7 @@
 #   2. Training providers (visible in https://falco.org/training)
 #
 # You can add a new entry specifying the next fields: `src`, `alt` and `url`.
+# More metadata is available for training courses (see below).
 #
 # And remember to include your logo in png format here:
 #   1. static/img/training/
@@ -167,13 +168,37 @@ url = "https://github.com/statsd/statsd"
 # -------------------------------------------------------------------------------------
 # Training resources provided by the community
 # -------------------------------------------------------------------------------------
+# For every new training contributor, add a new [[training.contribution]] entry.
+# include the src, alt and url fields for a general reference to the training site.
+# include an array courses, with one array per course [title, url]
+
+# [[training.contribution]]
+# src = "logo.png"
+# alt = "alternative text for the image media"
+# url = "URL to training main page"
+# courses = [
+#             ["course1_title", "course1_url", "course1_desc"], 
+#             ["course2_title", "course2_url", "course2_desc"], 
+#             ["course3_title", "course3_url", "course3_desc"]
+#         ]
 
 [[training.contribution]]
 src = "katacoda.png"
 alt = "Falco & CNCF Training by Katacoda (O'Reilly)"
 url = "https://www.katacoda.com/falco/courses/falco"
+courses = [
+            ["Container runtime security with Falco", "https://www.katacoda.com/falco/courses/falco/falco", "Learn how to use Falco to detect anomalous behaviour and create your own container security policy"], 
+            ["Practical example of Kubernetes runtime security with Falco", "https://www.katacoda.com/falco/courses/falco/forensics-k8s", "This scenario teaches you how to use Falco for container forensics on a Kubernetes cluster"],
+            ["Falcosidekick: Blocking security threats with Falco Response Engine", "https://www.katacoda.com/falco/courses/falco/falco-falcosidekick", "This scenario teaches you how to use Falcosidekick Response Engine on a Kubernetes cluster"]
+
+        ]
 
 [[training.contribution]]
 src = "sysdig.png"
 alt = "Falco 101 course by Sysdig"
 url = "https://learn.sysdig.com/path/falco"
+courses = [
+            ["Falco 101", "https://learn.sysdig.com/path/falco/falco-101", "All you need to learn to get started with Falco"], 
+            ["Falco Plugins", "https://learn.sysdig.com/path/falco/falco-plugins", "Extending Falco to secure your cloud services"], 
+            ["Detecting a Cryptomining Malware attack with Falco and Prometheus", "https://learn.sysdig.com/path/falco/detecting-a-crytomining-malware-attack-with-falco-and-prometheus", "Learn how to detect Cryptominers with Falco and Prometheus"]
+        ]

--- a/layouts/partials/training.html
+++ b/layouts/partials/training.html
@@ -1,6 +1,7 @@
 {{ $training := $.Site.Params.training }}
 {{ $contributors := index $training "contribution" }}
 
+
 <section class="row relative td-box--gradient td-box--height-auto">
     <div class="container text-center">
 
@@ -15,12 +16,19 @@
 
         <div class="row h-30">
             {{- range $contributors }}
-            <div class="col-xs-12 col-sm-6 col-md-3 px-5 pb-3 my-auto">
+            <div class="col-xs-12 col-sm-6 col-md-3 px-3 pb-3">
             <figure>
                 <a href="{{ .url }}">
                 <img class="img-fluid mb-4" src="{{ printf "/img/training/%s" .src | relURL }}"
                     alt="{{ .alt }}">
                 </a>
+                <!-- https://mertbakir.gitlab.io/hugo/loops-in-hugo/ -->
+                <ul  style=text-align:left;list-style-type:circle;>
+                {{ range $course := .courses }}
+                <li><a style=font-size:75%; href="{{ index . 1 }}" target="_blank" title="Course Description: {{ index . 2 }}">{{ index . 0 }}</a></li>
+                {{ end }}
+                </ul>
+
             </figure>
             </div>
             {{- end }}


### PR DESCRIPTION
Signed-off-by: pablopez <pablo.lopezzaldivar@sysdig.com>

**What type of PR is this?**
/kind user-interface

**Any specific area of the project related to this PR?**
/area training

**What this PR does / why we need it**:
Adds more detail to content providers, now course title, description and links can be added.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
None, I tested it locally and it is working fine. It also follows the same TOML file structure to add new data in the config file, no need to edit any other part of the blog sources.