### PR TITLE
Fix first time make serve command fail due to not downloaded submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	rm -rf public
 
 dependencies:
-	(npm install && cd themes/docsy && git submodule update -f --init && cd ../..)
+	npm install && git submodule update -f --init --recursive
 
 serve: dependencies
 	hugo server --minify \
@@ -18,7 +18,7 @@ preview-build: dependencies
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \
 		--buildFuture \
-		--minify 
+		--minify
 	make check-links
 
 link-checker-setup:


### PR DESCRIPTION
According to documentation to run locally the website you should run:
`make serve`
This command fails on a clean checkout. The reason is that the submodule docksy has some submodules inside that aren't downloaded. Changed the submodule init to run recursively so that error doesn't happen.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
