### PR TITLE
Display the CRI options where K3s is used

### DIFF
--- a/content/en/docs/getting-started/third-party/production.md
+++ b/content/en/docs/getting-started/third-party/production.md
@@ -60,3 +60,18 @@ If you are [installing Falco with Helm](https://falco.org/docs/getting-started/t
 ```
 helm install falco falcosecurity/falco --set ebpf.enabled=true
 ```
+
+### K3s
+
+[K3s](https://k3s.io/) is a lightweight, CNCF certified Kubernetes distribution. It has embedded components like etcd (datastore), CoreDNS, traefik ingress controller and etc. to simplify Kubernetes installation or upgrade.
+
+If you are using K3s with containerd, you should set the CRI settings because the socket path is different from the default setting configured in Falco.
+
+- If you install Falco on host machine
+  - Append the parameter ```--cri /run/k3s/containerd/containerd.sock``` when starting the Falco binary.
+- If you install Falco inside K3s with Helm
+  - Append below options when install with Helm:
+
+  ```shell
+  --set containerd.enabled=true --set containerd.socket=/run/k3s/containerd/containerd.sock
+  ```


### PR DESCRIPTION
Let users know about the CRI options (provided by @pabloopez) to use when using K3S
Original discussion is in here https://github.com/falcosecurity/falco/issues/1911

https://github.com/falcosecurity/falco-website/pull/560#pullrequestreview-994562513

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**
Documentation

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:
Let users know what parameters should be configured for CRI when using K3S.
The default setting used in Falco does not match the one used in K3S.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #
N/A

**Special notes for your reviewer**:
Original PR is https://github.com/falcosecurity/falco-website/pull/560
There is discussion inside that PR for the discussion.
For a cleaner diff/patch , I created another PR.