### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,18 +3,8 @@ approvers:
   - jasondellaluce
   - Issif
 reviewers:
-  - fntlnz
-  - leodido
   - danpopsd
-  - kris-nova
-  - mfdii
-  - lucperkins
   - mstemm
-  - radhikapc
-  - leogr
-  - Rajakavitha1
-  - jasondellaluce
-  - Issif
 emeritus_approvers:
   - fntlnz
   - leodido

--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,5 @@
 approvers:
-  - fntlnz
-  - leodido
-  - kris-nova
-  - mfdii
-  - lucperkins
-  - radhikapc
   - leogr
-  - Rajakavitha1
   - jasondellaluce
   - Issif
 reviewers:
@@ -22,3 +15,11 @@ reviewers:
   - Rajakavitha1
   - jasondellaluce
   - Issif
+emeritus_approvers:
+  - fntlnz
+  - leodido
+  - kris-nova
+  - mfdii
+  - lucperkins
+  - radhikapc
+  - Rajakavitha1

--- a/content/ml/OWNERS
+++ b/content/ml/OWNERS
@@ -1,6 +1,6 @@
-approvers:
-  - radhikapc
-  - sreedaum
 reviewers:
   - sreedaum
   - radhikapc
+emeritus_approvers:
+  - radhikapc
+  - sreedaum

--- a/content/ml/OWNERS
+++ b/content/ml/OWNERS
@@ -1,6 +1,3 @@
-reviewers:
-  - sreedaum
-  - radhikapc
 emeritus_approvers:
   - radhikapc
   - sreedaum


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
