### PR TITLE
Update docs for json_output option to reflect alerts+rules result

### DIFF
--- a/data/en/config.yaml
+++ b/data/en/config.yaml
@@ -18,11 +18,12 @@
     If `true` (default is `false`), the times displayed in log messages and output messages will be in ISO 8601. By default, times are displayed in the local time zone, as governed by /etc/localtime.
 - name: json_output
   type: Boolean
-  description: Whether to use JSON output for alert messages.
+  description: |
+    If `true`, print falco alert messages and rules file loading/validation results as json, which allows for easier consumption by downstream programs. Default is `false`.
 - name: json_include_output_property
   type: Boolean
   description: |
-    When using json output, whether or not to include the `output` property itself (e.g. `File below a known binary directory opened for writing (user=root ....`) in the JSON output.
+    When using json output for falco alerts, whether or not to include the `output` property itself (e.g. `File below a known binary directory opened for writing (user=root ....`) in the JSON output.
 - name: log_stderr
   type: Boolean
   description: |


### PR DESCRIPTION
Related to the changes in
https://github.com/falcosecurity/falco/pull/2098, update the docs for
the json_output config option to note that it controls both the output
format for falco alerts as well as the format of rules
loading/validation results.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
