### PR TITLE
update(content/en/docs): sync cli option list with Falco 0.33

### DIFF
--- a/content/en/docs/getting-started/running/arguments.md
+++ b/content/en/docs/getting-started/running/arguments.md
@@ -13,12 +13,13 @@ Usage:
 
   -h, --help                    Print this page
   -c <path>                     Configuration file. If not specified uses /etc/falco/falco.yaml.
-  -A                            Monitor all events, including those with EF_DROP_SIMPLE_CONS flag.
+  -A                            Monitor all events, including those not interesting to Falco. Please use the -i option to list all ignored 
+                                events. This option has effect only on live captures.
   -b, --print-base64            Print data buffers in base64. This is useful for encoding binary data that needs to be used over media 
                                 designed to consume this format.
       --cri <path>              Path to CRI socket for container metadata. Use the specified socket to fetch data from a CRI-compatible 
-                                runtime. If not specified, uses libs default. It can be passed multiple times to specify socket to be tried 
-                                until a successful one is found.
+                                runtime. If not specified, uses the libs default. This option can be passed multiple times to specify 
+                                socket to be tried until a successful one is found.
   -d, --daemon                  Run as a daemon.
       --disable-cri-async       Disable asynchronous CRI metadata fetching. This is useful to let the input event wait for the container 
                                 metadata fetch to finish before moving forward. Async fetching, in some environments leads to empty fields 
@@ -26,11 +27,25 @@ Usage:
                                 performance penalty on your environment depending on the number of containers and the frequency at which 
                                 they are created/started/stopped.
       --disable-source <event_source>
-                                Disable a specific event source. Available event sources are: syscall or any source from a configured 
-                                plugin with event sourcing capability. It can be passed multiple times. Can not disable all event sources.
-  -D <substring>                Disable any rules with names having the substring <substring>. Can be specified multiple times. Can not be 
-                                specified with -t.
-  -e <events_file>              Read the events from <events_file> in .scap format instead of tapping into live.
+                                Disable a specific event source. By default, all loaded sources get enabled. Available sources are 
+                                'syscall' and all sources defined by loaded plugins supporting the event sourcing capability. This option 
+                                can be passed multiple times. This has no offect when reading events from a trace file. Can not disable all 
+                                event sources. Can not be mixed with --enable-source.
+  -D <substring>                Disable any rules with names having the substring <substring>. This option can be passed multiple times. 
+                                Can not be mixed with -t.
+  -e <events_file>              Read the events from a trace file <events_file> in .scap format instead of tapping into live.
+      --enable-source <event_source>
+                                Enable a specific event source. If used, all loaded sources get disabled by default and only the ones 
+                                passed with this option get enabled. Available sources are 'syscall' and all sources defined by loaded 
+                                plugins supporting the event sourcing capability. This option can be passed multiple times. This has no 
+                                offect when reading events from a trace file. Can not be mixed with --disable-source.
+  -g, --gvisor-config <gvisor_config>
+                                Parse events from gVisor using the specified configuration file. A falco-compatible configuration file can 
+                                be generated with --gvisor-generate-config and can be used for both runsc and Falco.
+      --gvisor-generate-config [=<socket_path>(=/run/falco/gvisor.sock)]
+                                Generate a configuration file that can be used for gVisor.
+      --gvisor-root <gvisor_root>
+                                gVisor root directory for storage of container state. Equivalent to runsc --root flag.
   -i                            Print all events that are ignored by default (i.e. without the -A flag) and exit.
   -k, --k8s-api <url>           Enable Kubernetes support by connecting to the API server specified as argument. E.g. 
                                 "http://admin:password@127.0.0.1:8080". The API server can also be specified via the environment variable 
@@ -43,7 +58,7 @@ Usage:
                                 entry is provided for this option, it will be interpreted as the name of a file containing bearer token. 
                                 Note that the format of this command-line option prohibits use of files whose names contain ':' or '#' 
                                 characters in the file name.
-      --k8s-node <node_name>    The node name will be used as a filter when requesting metadata of pods to the API server. Usually, it 
+      --k8s-node <node_name>    The node name will be used as a filter when requesting metadata of pods to the API server. Usually, this 
                                 should be set to the current node on which Falco is running. If empty, no filter is set, which may have a 
                                 performance penalty on large clusters.
   -L                            Show the name and description of all rules and exit.
@@ -65,6 +80,11 @@ Usage:
                                     E.g. base.id = val
                                          base.subvalue.subvalue2 = val
                                          base.list[1]=val
+      --plugin-info <plugin_name>
+                                Print info for a single plugin and exit.
+                                This includes all descriptivo info like name and author, along with the
+                                schema format for the init configuration and a list of suggested open parameters.
+                                <plugin_name> can be the name of the plugin or its configured library_path.
   -p, --print <output_format>   Add additional information to each falco notification's output.
                                 With -pc or -pcontainer will use a container-friendly format.
                                 With -pk or -pkubernetes will use a kubernetes-friendly format.
@@ -72,8 +92,8 @@ Usage:
                                 Additionally, specifying -pc/-pk/-pm will change the interpretation of %container.info in rule output 
                                 fields.
   -P, --pidfile <pid_file>      When run as a daemon, write pid to specified file (default: /var/run/falco.pid)
-  -r <rules_file>               Rules file/directory (defaults to value set in configuration file, or /etc/falco_rules.yaml). Can be 
-                                specified multiple times to read from multiple files/directories.
+  -r <rules_file>               Rules file/directory (defaults to value set in configuration file, or /etc/falco_rules.yaml). This option 
+                                can be passed multiple times to read from multiple files/directories.
   -s <stats_file>               If specified, append statistics related to Falco's reading/processing of events to this file (only useful 
                                 in live mode).
       --stats-interval <msec>   When using -s <stats_file>, write statistics every <msec> ms. This uses signals, so don't recommend 
@@ -81,14 +101,16 @@ Usage:
   -S, --snaplen <len>           Capture the first <len> bytes of each I/O buffer. By default, the first 80 bytes are captured. Use this 
                                 option with caution, it can generate huge trace files. (default: 0)
       --support                 Print support information including version, rules files used, etc. and exit.
-  -T <tag>                      Disable any rules with a tag=<tag>. Can be specified multiple times. Can not be specified with -t
-  -t <tag>                      Only run those rules with a tag=<tag>. Can be specified multiple times. Can not be specified with -T/-D.
+  -T <tag>                      Disable any rules with a tag=<tag>. This option can be passed multiple times. Can not be mized with -t
+  -t <tag>                      Only run those rules with a tag=<tag>. This option can be passed multiple times. Can not be mixed with 
+                                -T/-D.
   -U, --unbuffered              Turn off output buffering to configured outputs. This causes every single line emitted by falco to be 
                                 flushed which generates higher CPU usage but is useful when piping those outputs into another process or 
                                 into a script.
   -u, --userspace               Parse events from userspace. To be used in conjunction with the ptrace(2) based driver (pdig)
-  -V, --validate <rules_file>   Read the contents of the specified rules(s) file and exit. Can be specified multiple times to validate 
-                                multiple files.
+  -V, --validate <rules_file>   Read the contents of the specified rules(s) file and exit. This option can be passed multiple times to 
+                                validate multiple files.
   -v                            Verbose output.
       --version                 Print version number.
+      --page-size               Print the system page size (may help you to choose the right syscall ring-buffer size).
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

This syncs the list of supported CLI options with the new list coming from Falco 0.33.0.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/hold until Falco 0.33.0 gets released
