### PR TITLE
update(content/docs): correct dummy plugin Go source code link

### DIFF
--- a/content/en/docs/plugins/go-sdk-walkthrough.md
+++ b/content/en/docs/plugins/go-sdk-walkthrough.md
@@ -262,7 +262,7 @@ The SDK takes care of generating all the required C exported functions that the 
 
 This section walks through the implementation of the `dummy`. This plugin returns events that are just a number value that increases with each event generated. Each increase is 1 plus a random "jitter" value that ranges from [0:jitter]. The jitter value is provided as configuration to the plugin in `plugin_init`. The starting value and the maximum number of events are provided as open parameters to the plugin in `plugin_open`.
 
-This will show how the above API functions are actually used in a functional plugin. The source code for this plugin can be found at [dummy.go](https://github.com/falcosecurity/plugins/blob/master/plugins/dummy/dummy.go).
+This will show how the above API functions are actually used in a functional plugin. The source code for this plugin can be found at [dummy.go](https://github.com/falcosecurity/plugins/blob/master/plugins/dummy/plugin/dummy.go).
 
 ### Initial Imports
 


### PR DESCRIPTION
Signed-off-by: Matthew White <matthew.w.white@oracle.com>

**What type of PR is this?**

/kind cleanup

/kind content

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

Corrects the link to the dummy plugin Go source code in the dummy walkthrough.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

I'm assuming the entrypoint/main is correct for this, despite there being another `dummy.go` in the `pkg` directory.