### PR TITLE
update(docs): version params

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -158,16 +158,6 @@ copyright_linux =  "The Linux Foundation ®."
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
 
-# Flag used in the "version-banner" partial to decide whether to display a
-# banner on every page indicating that this is an archived version of the docs.
-# Set this flag to "true" if you want to display the banner.
-archived_version = false
-
-# The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the
-# current doc set.
-version = "v0.33.0"
-
 # SHA256 checksum variable
 sha256sum = "59201c1339cc53e86edcd7d2e7273e52f784b3cf7d4a3142059112b3b9062f6d"
 
@@ -344,62 +334,6 @@ languagedirection = "ltr"
 [languages.ml.params]
 time_format_blog = "2006.01.02"
 language_alternatives = ["en"]
-
-[[params.versions]]
-fullversion = "v0.26.2"
-version = "v0.26"
-githubbranch = "0.26.2"
-docsbranch = "v0.26"
-url = "https://v0-26.falco.org/"
-
-[[params.versions]]
-fullversion = "v0.27.0"
-version = "v0.27"
-githubbranch = "0.27.0"
-docsbranch = "v0.27"
-url = "https://v0-27.falco.org"
-
-[[params.versions]]
-fullversion = "v0.28.1"
-version = "v0.28"
-githubbranch = "0.28.1"
-docsbranch = "v0.28"
-url = "https://v0-28.falco.org"
-
-[[params.versions]]
-fullversion = "v0.29.1"
-version = "v0.29"
-githubbranch = "0.29.1"
-docsbranch = "v0.29"
-url = "https://v0-29.falco.org/"
-
-[[params.versions]]
-fullversion = "v0.30.0"
-version = "v0.30"
-githubbranch = "0.30.0"
-docsbranch = "v0.30"
-url = "https://v0-30.falco.org/"
-
-[[params.versions]]
-fullversion = "v0.31.1"
-version = "v0.31"
-githubbranch = "0.31.1"
-docsbranch = "v0.31"
-url = "https://v0-31.falco.org/"
-
-[[params.versions]]
-fullversion = "v0.32.2"
-version = "v0.32"
-githubbranch = "0.32.2"
-docsbranch = "v0.32"
-url = "https://v0-32.falco.org"
-
-[[params.versions]]
-fullversion = "v0.33.0"
-version = "v0.33"
-githubbranch = "master"
-docsbranch = "master"
-url = "https://falco.org"
 
 # To edit the list of Adopters or Training Providers, go to `./params.toml`
 

--- a/config/_default/versions/params.yaml
+++ b/config/_default/versions/params.yaml
@@ -1,0 +1,66 @@
+---
+# Flag used in the "version-banner" partial to decide whether to display a
+# banner on every page indicating that this is an archived version of the docs.
+# Set this flag to "true" if you want to display the banner.
+
+archived_version: false
+
+# The version number for the version of the docs represented in this doc set.
+# Used in the "version-banner" partial to display a version number for the
+# current doc set.
+
+version: v0.33.0
+
+# The archived versions of the docs available for reference.
+# Used in the Releases menu, as well as in the Available Documentation Versions
+
+versions:
+
+  - fullversion: v0.33.0
+    version: v0.33
+    githubbranch: master
+    docsbranch: master
+    url: https://falco.org/
+
+  - fullversion: v0.32.2
+    version: v0.32
+    githubbranch: 0.32.2
+    docsbranch: master
+    url: https://v0-32.falco.org/
+
+  - fullversion: v0.31.1
+    version: v0.31
+    githubbranch: 0.31.1
+    docsbranch: v0.31
+    url: https://v0-31.falco.org/
+
+  - fullversion: v0.30.0
+    version: v0.30
+    githubbranch: 0.30.0
+    docsbranch: v0.30
+    url: https://v0-30.falco.org/
+
+  - fullversion: v0.29.1
+    version: v0.29
+    githubbranch: 0.29.1
+    docsbranch: v0.29
+    url: https://v0-29.falco.org/
+
+  - fullversion: v0.28.1
+    version: v0.28
+    githubbranch: 0.28.1
+    docsbranch: v0.28
+    url: https://v0-28.falco.org/
+
+  - fullversion: v0.27.0
+    version: v0.27
+    githubbranch: 0.27.0
+    docsbranch: v0.27
+    url: https://v0-27.falco.org/
+
+  - fullversion: v0.26.2
+    version: v0.26
+    githubbranch: 0.26.2
+    docsbranch: v0.26
+    url: https://v0-26.falco.org/
+

--- a/content/en/docs/supported-doc-versions.md
+++ b/content/en/docs/supported-doc-versions.md
@@ -1,0 +1,13 @@
+---
+title: Available Documentation Versions
+content_type: custom
+layout: supported-versions
+weight: 200
+card:
+  name: about
+  weight: 10
+  title: Available Documentation Versions
+---
+
+This website contains documentation for the current version of Falco
+as well as up to six previous versions.

--- a/i18n/en/supported-versions/en.yaml
+++ b/i18n/en/supported-versions/en.yaml
@@ -1,0 +1,9 @@
+---
+docs_version_latest_heading:
+  other: Latest version
+
+docs_version_other_heading:
+  other: Older versions
+
+docs_version_current:
+  other: ' (this documentation)'

--- a/layouts/docs/supported-versions.html
+++ b/layouts/docs/supported-versions.html
@@ -1,0 +1,41 @@
+{{ define "main" }}
+    <div class="td-content">
+    {{ partial "docs/content-page" (dict "ctx" . "page" .) }}
+    {{ $versions := .Page.Param "versions" }}
+    {{ $thisPageRelUri := .Page.RelPermalink }}
+    {{ $thisVersionArray := first 2 (split (.Page.Param "version") ".") }}
+    {{ $.Scratch.Set "version-class" (slice "placeholder") }}
+    {{/* "placeholder" is also used later to check whether we opened the <ul> */}}
+    {{ range $index, $version := $versions }}
+    {{ $.Scratch.Set "version-class" (slice "") }}
+    {{ $versionArray := split .version "." }}
+
+    {{ if eq $index 0 }}
+    <h2 id="version-latest">{{ T "docs_version_latest_heading" }}</h2>
+    <ul>
+    {{ $.Scratch.Set "version-class" ($.Scratch.Get "version-class" | append "version-latest" ) }}
+    {{ end }}
+    {{ if eq $index 1 }}
+    </ul>
+    <h2 id="versions-older">{{ T "docs_version_other_heading" }}</h2>
+    <ul>
+    {{ end }}
+
+    {{ if eq .version ( delimit $thisVersionArray "." ) }}
+    {{ $.Scratch.Set "version-class" ($.Scratch.Get "version-class" | append "version-current" ) }}
+    {{ end }}
+
+    <li class="{{ delimit ( $.Scratch.Get "version-class") " " }}">
+        <!-- Recent implementation of this feature not supported in previous versions yet -->
+        <!-- <a href="{{ .url }}{{ $thisPageRelUri }}">{{ .version }}</a> -->
+        <a href="{{ .url }}docs/">{{ .version }}</a>
+        {{ if eq .version ( delimit $thisVersionArray "." ) }}
+        {{ T "docs_version_current" }}
+        {{ end }}
+    </li>
+    {{ end }}
+    {{ if ne (index ($.Scratch.Get "version-class") 0) "placeholder" }}
+    </ul>
+    {{ end }}
+
+{{ end }}

--- a/layouts/partials/docs/content-page.html
+++ b/layouts/partials/docs/content-page.html
@@ -1,0 +1,6 @@
+{{ if not .page.Params.notitle }}
+  <h1>{{ .page.Title }}</h1>
+  {{ $desc := .page.Description }}
+  {{ with .page.Params.description }}<div class="lead">{{ $desc | markdownify }}</div>{{ end }}
+{{ end }}
+{{ .page.Content }}

--- a/release.md
+++ b/release.md
@@ -23,23 +23,33 @@ The following instructions assume **`v0.x.y` is the version to be archived**.
 
 1. Create the new `v0.x` branch from the current `master` branch.
 2. Configure [the branch deploy control on Netlify](https://docs.netlify.com/site-deploys/overview/#branch-deploy-controls) by adding the newly created branch `v0.x`.
-3. Within the `v0.x` branch, edit the [config.toml]([config.toml](_default/config.toml)) file:
-    - set `archived_version` to `true`,
-    - make sure `version` is equal to `v0.x.y`,
-    - finally, commit and push to `v0.x`.
+3. Within the `v0.x` branch, edit the [versions/params.yaml](config/_default/versions/params.yaml) file:
+    - Set `archived_version` to `true`,
+    - Make sure `version` is equal to `v0.x.y`,
+    - Update the YAML block refering to `v0.x.y` (i.e., *the previous version*) as following:
+    ```yaml
+    versions:
+
+      - fullversion: v0.x.y
+        version: v0.x
+        githubbranch: 0.x.y
+        docsbranch: v0.x
+        url: https://v0-x.falco.org/
+    ```
+    - Finally, commit and push to `v0.x`.
 4. Once the Netlify branch build is done (see the [Deploys section](https://app.netlify.com/sites/falcosecurity/deploys)), add a new [branch subdomain on Netilify](https://docs.netlify.com/domains-https/custom-domains/multiple-domains/#branch-subdomains) by selecting the branch deploy configured in the previous step.
 5. Open a [PR in falcosecurity/test-infra](https://github.com/falcosecurity/test-infra/edit/master/config/config.yaml) to add `v0.x` as protected branch to the `prow/config.yaml`, for example:
 
     ```yaml
-            falco-website:
-              branches:
-                master:
-                  protect: true
-                v0.26:
-                  protect: true
-                ...
-                v0.x:
-                  protect: true
+    falco-website:
+      branches:
+        master:
+          protect: true
+        v0.26:
+          protect: true
+        ...
+        v0.x:
+          protect: true
     ```
 
 ### Bump the version on the current website
@@ -48,24 +58,22 @@ The following instructions assume **`v0.x.y` is the version to be archived**.
 >
 The following instructions assume **`v0.X.Y` is the new version** and **v0.x.y** is the previous already-archived version.
 
-1. Open a [PR in falcosecurity/falco-website](https://github.com/falcosecurity/falco-website/edit/update/master/config.toml) to modifiy the [config.toml](config.toml) file on the `master` branch:
-    - make sure `version` is set to `v0.X.Y` (i.e., *the new version*),
-    - append the following config for *the new version* to the end of the file:
-    ```toml
-    [[params.versions]]
-    fullversion = "v0.X.Y"
-    version = "vX.Y"
-    githubbranch = "master"
-    docsbranch = "master"
-    url = "https://falco.org"
+1. [Open a PR in the falcosecurity/falco-website repo](https://github.com/falcosecurity/falco-website/edit/master/config/_default/versions/params.yaml) to modify the [versions/params.yaml](config/_default/versions/params.yaml) file on the `master` branch:
+    - Make sure the `version` field is set to `v0.X.Y` (i.e., *the new version*).
+    - **Insert** the following config block for *the new version* as the first entry of the list, right after the `versions:` line. Make sure the indentation is right (it should align with the adyacent blocks) and tabs should be avoided.
+    ```yaml
+      - fullversion: v0.X.Y
+        version: vX.Y
+        githubbranch: master
+        docsbranch: master
+        url: https://falco.org/
     ```
-    - change the `[[params.versions]]` block refering to `v0.x.y` (i.e., *the previous version*) as following:
-    ```toml
-    [[params.versions]]
-    fullversion = "v0.x.y"
-    version = "v0.x"
-    githubbranch = "0.x.y"
-    docsbranch = "v0.x"
-    url = "https://v0-x.falco.org"
+    - Update the current second YAML block refering to `v0.x.y` (i.e., *the previous version*) as following:
+    ```yaml
+      - fullversion: v0.x.y
+        version: v0.x
+        githubbranch: 0.x.y
+        docsbranch: v0.x
+        url: https://v0-x.falco.org/
     ```
 2. Once the PR gets approved and merged, the website will be updated shortly, and no other actions are needed.


### PR DESCRIPTION
This PR:

- Changes the order of how documentation versions are displayed under releases.
- Moves the configuration for that into a separate file, where all required changes take place when archiving.
- Adds an Available Documentation Versions page to display these inside the documentation.

Signed-off-by: Vicente J. Jiménez Miras <vjjmiras@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

> /area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
