### PR TITLE
new docs/reference section

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -1,0 +1,9 @@
+---
+title: Reference
+main_menu: true
+weight: 95
+content_type: concept
+no_list: false
+no_edit: true
+hide_feedback: true
+---

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,3 +1,4 @@
+{{ if not .Params.no_edit }}
 {{ if .File }}
 {{ $pathFormatted := replace .File.Path "\\" "/" -}}
 {{ $gh_repo := ($.Param "github_repo") -}}
@@ -40,3 +41,5 @@
 {{ end -}}
 
 {{ end -}}
+
+{{ end }}


### PR DESCRIPTION
This PR adds the possibility of adding the no_edit option in the FrontMatter section to hide the meta links on the right side.

Signed-off-by: Vicente J. Jiménez Miras <vjjmiras@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
