### PR TITLE
fix: improve Debian instructions

### DIFF
--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -74,13 +74,13 @@ Let's see an example of how to install the package in a Debian-like system, for 
 3. Update the package list
 
     ```bash
-    sudo apt-get update -y
+    ```
     
     > In older versions of Debian (those previous to Debian 10), you might need to additionally install the package `apt-transport-https` to allow access to the Falco repository.
     > To do so, you can run the following command:
     >
     > sudo apt-get install apt-transport-https
-    ```
+    
 
 4. Install some required dependencies that are needed to build the kernel module and the BPF probe
 

--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -74,6 +74,7 @@ Let's see an example of how to install the package in a Debian-like system, for 
 3. Update the package list
 
     ```bash
+    sudo apt-get update -y
     ```
     
     > In older versions of Debian (those previous to Debian 10), you might need to additionally install the package `apt-transport-https` to allow access to the Falco repository.

--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -75,6 +75,11 @@ Let's see an example of how to install the package in a Debian-like system, for 
 
     ```bash
     sudo apt-get update -y
+    
+    > In older versions of Debian (those previous to Debian 10), you might need to additionally install the package `apt-transport-https` to allow access to the Falco repository.
+    > To do so, you can run the following command:
+    >
+    > sudo apt-get install apt-transport-https
     ```
 
 4. Install some required dependencies that are needed to build the kernel module and the BPF probe

--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -62,29 +62,29 @@ Let's see an example of how to install the package in a Debian-like system, for 
 1. Trust the `falcosecurity` GPG key
 
     ```bash
-    curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add -
+    curl -fsSL https://falco.org/repo/falcosecurity-packages.asc | sudo gpg --dearmor -o /usr/share/keyrings/falco-archive-keyring.gpg
     ```
 
 2. Configure the apt repository
 
     ```bash
-    echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list
+    echo "deb [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main" | sudo tee -a /etc/apt/sources.list.d/falcosecurity.list
     ```
 
 3. Update the package list
 
     ```bash
-    apt-get update -y
+    sudo apt-get update -y
     ```
 
 4. Install some required dependencies that are needed to build the kernel module and the BPF probe
 
     ```bash
-    apt install -y dkms make linux-headers-$(uname -r)
+    sudo apt install -y dkms make linux-headers-$(uname -r)
     # If you use the falco-driver-loader to build the BPF probe locally you need also clang toolchain
-    apt install -y clang llvm
+    sudo apt install -y clang llvm
     # You can install also the dialog package if you want it
-    apt install -y dialog
+    sudo apt install -y dialog
     ```
 
     > _Note_: You don't need to install these deps if you want to the modern BPF probe
@@ -92,7 +92,7 @@ Let's see an example of how to install the package in a Debian-like system, for 
 5. Install the Falco package
 
     ```bash
-    apt-get install -y falco
+    sudo apt-get install -y falco
     ```
 
 #### Installation with dialog


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

 /kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

This PR improves the Debian installation instructions as they are currently relying on a deprecated and soon to be removed tool (apt-key).

The refactored instructions follow best practice in terms of apt source handling to improve the system security as well as working as a power user rather than root.

**Special notes for your reviewer**:

Nothing particular