### PR TITLE
Add page for rules editor support

### DIFF
--- a/content/en/docs/rules/ide-support.md
+++ b/content/en/docs/rules/ide-support.md
@@ -1,0 +1,14 @@
+---
+title: IDE Support
+description: IDE Support for Falco Rules Files
+linktitle: IDE Support
+weight: 250
+---
+
+For some Integrated Development Environment (IDE) Editors, there is support for falco rules files that allow for on-the-fly syntax checking and validation of rules content.
+
+#### Emacs
+
+For emacs, there is a [Flycheck](https://www.flycheck.org) checker called [flycheck-falco-rules](https://github.com/falcosecurity/flycheck-falco-rules):
+
+![](https://github.com/falcosecurity/flycheck-falco-rules/raw/main/flycheck-falco-rules-example.png)


### PR DESCRIPTION
Add a page noting editor support for falco rules files. Currently only flycheck-falco-rules for emacs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

Now that the emacs syntax checker [flycheck-falco-rules](https://github.com/falcosecurity/flycheck-falco-rules) has been donated to falcosecurity and is available on MELPA (https://github.com/melpa/melpa/pull/8403), add a page about editor support for falco rules files and point to the flycheck-falco-rules repo.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
