### PR TITLE
fix: added missing "deb" type in apt source.list

### DIFF
--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -70,7 +70,7 @@ Let's see an example of how to install the package in a Debian-like system, for 
 
     ```bash
     sudo cat >>/etc/apt/sources.list.d/falcosecurity.list <<EOF
-    [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main
+    deb [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main
     EOF
     ```
 


### PR DESCRIPTION
**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

Given installation instructions don't work

Fixes #

 * Adds missing "deb" type in apt source.list installation instruction

**Special notes for your reviewer**:

This PR fixes a syntax issue given in the documentation to install falco from apt source.list
