### PR TITLE
GitOps Falco Rules - wrong featured image path

### DIFF
--- a/content/en/blog/gitops-your-falco-rules/index.md
+++ b/content/en/blog/gitops-your-falco-rules/index.md
@@ -6,7 +6,7 @@ author: Vicente J. Jiménez Miras
 slug: gitops-your-falco-rules
 tags: ["Rules","Falcoctl"]
 images:
-  - images/gitops-your-falco-rules-featured.png
+  - /blog/gitops-your-falco-rules/images/gitops-your-falco-rules-featured.png
 ---
 
 Falco rules management has been a discussed topic for quite a long time. When we start building and customizing rules for our environment, we need a simple way to effectively update and distribute them to our Falco fleet. Starting from Falco 0.34, we can easily do it by using OCI artifacts and leveraging any private or public container registry to store and retrieve them.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area blog

> /area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
