### PR TITLE
fix #791 - json_output option influences --version output

### DIFF
--- a/data/en/reference/daemon/config_options.yaml
+++ b/data/en/reference/daemon/config_options.yaml
@@ -56,7 +56,7 @@
 - name: json_output
   type: Boolean
   description: |
-    If `true` (default is `false`), print falco alert messages and rules file loading/validation results as json, which allows for easier consumption by downstream programs. Default is `false`.
+    If `true` (default is `false`), print falco alert messages and rules file loading/validation results as json, which allows for easier consumption by downstream programs. Also changes falco `--version` CLI argument output as json.
 
 - name: json_include_output_property
   type: Boolean


### PR DESCRIPTION
Add a clarifying blurb for `json_output` config option

**What type of PR is this?**

> /kind content

**Any specific area of the project related to this PR?**

> /area documentation

Fixes #791 
