### PR TITLE
update(params.yaml): bump website to falco v0.35.0

### DIFF
--- a/config/_default/versions/params.yaml
+++ b/config/_default/versions/params.yaml
@@ -9,17 +9,23 @@ archived_version: false
 # Used in the "version-banner" partial to display a version number for the
 # current doc set.
 
-version: v0.34.1
+version: v0.35.0
 
 # The archived versions of the docs available for reference.
 # Used in the Releases menu, as well as in the Available Documentation Versions
 
 versions:
-  - fullversion: v0.34.1
-    version: v0.34
+  - fullversion: v0.35.0
+    version: v0.35
     githubbranch: master
     docsbranch: master
     url: https://falco.org/
+        
+  - fullversion: v0.34.1
+    version: v0.34
+    githubbranch: 0.34.1
+    docsbranch: v0.34
+    url: https://v0-34.falco.org/
 
   - fullversion: v0.33.1
     version: v0.33


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

Sets the latest Falco version in the website. The previous version has been archived with a snapshot available at https://v0-34.falco.org and maintained in the [v0.34 branch](https://github.com/falcosecurity/falco-website/tree/v0.34).

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
