### PR TITLE
Document fs.path.* fields

### DIFF
--- a/content/en/docs/rules/fspath.md
+++ b/content/en/docs/rules/fspath.md
@@ -48,47 +48,39 @@ The below tables show:
 
 #### Single Argument File System Syscalls
 
-| Syscall  | Falco Libs Event Identifier   | `fs.path.name` field | From Enter Event?|
-| -------  | ------------------------------| ---------------------|------------------|
-| mkdir    | `PPME_SYSCALL_MKDIR`          | `evt.rawarg.path`    | Yes              |
-| mkdir    | `PPME_SYSCALL_MKDIR_2`        | `evt.rawarg.path`    | No               |
-| mkdirat  | `PPME_SYSCALL_MKDIRAT`        | `evt.rawarg.path`    | No               |
-| rmdir    | `PPME_SYSCALL_RMDIR`          | `evt.rawarg.path`    | Yes              |
-| rmdir    | `PPME_SYSCALL_RMDIR_2`        | `evt.rawarg.path`    | No               |
-| unlink   | `PPME_SYSCALL_UNLINK`         | `evt.rawarg.path`    | Yes              |
-| unlink   | `PPME_SYSCALL_UNLINK_2`       | `evt.rawarg.path`    | No               |
-| unlinkat | `PPME_SYSCALL_UNLINKAT`       | `evt.rawarg.name`    | Yes              |
-| unlinkat | `PPME_SYSCALL_UNLINKAT_2`     | `evt.rawarg.name`    | No               |
-| open     | `PPME_SYSCALL_OPEN`           | `evt.rawarg.name`    | No               |
-| openat   | `PPME_SYSCALL_OPENAT`         | `evt.rawarg.name`    | Yes              |
-| openat   | `PPME_SYSCALL_OPENAT_2`       | `evt.rawarg.name`    | No               |
-| openat2  | `PPME_SYSCALL_OPENAT2`        | `evt.rawarg.name`    | No               |
-| fchmod   | `PPME_SYSCALL_FCHMOD`         | `fd.name`            | No               |
-| fchmodat | `PPME_SYSCALL_FCHMODAT`       | `evt.rawarg.filename`| No               |
-| chmod    | `PPME_SYSCALL_CHMOD`          | `evt.rawarg.filename`| No               |
-| chown    | `PPME_SYSCALL_CHOWN`          | `evt.rawarg.path`    | No               |
-| lchown   | `PPME_SYSCALL_LCHOWN`         | `evt.rawarg.path`    | No               |
-| fchown   | `PPME_SYSCALL_FCHOWN`         | `fd.name`            | No               |
-| fchownat | `PPME_SYSCALL_FCHOWNAT`       | `evt.rawarg.pathname`| No               |
-| quotactl | `PPME_SYSCALL_QUOTACTL`       | `evt.rawarg.special` | No               |
-| umount   | `PPME_SYSCALL_UMOUNT`         | `evt.rawarg.name`    | No               |
-| umount   | `PPME_SYSCALL_UMOUNT_1`       | `evt.rawarg.name`    | No               |
-| umount2  | `PPME_SYSCALL_UMOUNT2`        | `evt.rawarg.name`    | No               |
+| Syscall  | `fs.path.name` field |
+| -------  | ---------------------|
+| mkdir    | `evt.rawarg.path`    |
+| mkdirat  | `evt.rawarg.path`    |
+| rmdir    | `evt.rawarg.path`    |
+| unlink   | `evt.rawarg.path`    |
+| unlinkat | `evt.rawarg.name`    |
+| open     | `evt.rawarg.name`    |
+| openat   | `evt.rawarg.name`    |
+| openat2  | `evt.rawarg.name`    |
+| fchmod   | `fd.name`            |
+| fchmodat | `evt.rawarg.filename`|
+| chmod    | `evt.rawarg.filename`|
+| chown    | `evt.rawarg.path`    |
+| lchown   | `evt.rawarg.path`    |
+| fchown   | `fd.name`            |
+| fchownat | `evt.rawarg.pathname`|
+| quotactl | `evt.rawarg.special` |
+| umount   | `evt.rawarg.name`    |
+| umount2  | `evt.rawarg.name`    |
 
 #### Source/Target File System Syscalls
 
-| Syscall    | Falco Libs Event Identifier   | `fs.path.source` field | `fs.path.target` field | From Enter Event? |
-| ---------- | ------------------------------| -----------------------| -----------------------| ------------------|
-| rename     | `PPME_SYSCALL_RENAME`         | `evt.rawarg.oldpath`   | `evt.arg.newpath`      | No                |
-| renameat   | `PPME_SYSCALL_RENAMEAT`       | `evt.rawarg.oldpath`   | `evt.arg.newpath`      | No                |
-| renameat2  | `PPME_SYSCALL_RENAMEAT2`      | `evt.rawarg.oldpath`   | `evt.arg.newpath`      | No                |
-| link       | `PPME_SYSCALL_LINK`           | `evt.rawarg.newpath`   | `evt.rawarg.oldpath`   | Yes               |
-| link       | `PPME_SYSCALL_LINK_2`         | `evt.arg.newpath`      | `evt.rawarg.oldpath`   | No                |
-| linkat     | `PPME_SYSCALL_LINKAT`         | `evt.rawarg.newpath`   | `evt.rawarg.oldpath`   | Yes               |
-| linkat     | `PPME_SYSCALL_LINKAT_2`       | `evt.arg.newpath`      | `evt.rawarg.oldpath`   | No                |
-| symlink    | `PPME_SYSCALL_SYMLINK`        | `evt.arg.linkpath`     | `evt.rawarg.target`    | No                |
-| symlinkat  | `PPME_SYSCALL_SYMLINKAT`      | `evt.arg.linkpath`     | `evt.rawarg.target`    | No                |
-| mount      | `PPME_SYSCALL_MOUNT`          | `evt.rawarg.dev`       | `evt.rawarg.dir`       | No                |
+| Syscall    | `fs.path.source` field | `fs.path.target` field |
+| ---------- | -----------------------| -----------------------|
+| rename     | `evt.rawarg.oldpath`   | `evt.arg.newpath`      |
+| renameat   | `evt.rawarg.oldpath`   | `evt.arg.newpath`      |
+| renameat2  | `evt.rawarg.oldpath`   | `evt.arg.newpath`      |
+| link       | `evt.arg.newpath`      | `evt.rawarg.oldpath`   |
+| linkat     | `evt.arg.newpath`      | `evt.rawarg.oldpath`   |
+| symlink    | `evt.arg.linkpath`     | `evt.rawarg.target`    |
+| symlinkat  | `evt.arg.linkpath`     | `evt.rawarg.target`    |
+| mount      | `evt.rawarg.dev`       | `evt.rawarg.dir`       |
 
 ### Example Rule Using `fs.path.*` Fields
 

--- a/content/en/docs/rules/fspath.md
+++ b/content/en/docs/rules/fspath.md
@@ -11,15 +11,15 @@ This section explains how the fields `fs.path.*` work and when they can be used.
 
 ### Motivation
 
-A variety of different syscalls take file system paths as arguments. However, there is little consistency in the fields that can access those file system paths. Depending on the syscall, the file system path might be available in `evt.rawarg.path`, `evt.rawarg.pathname`, `evt.rawarg.name`, `fd.name`, etc. And for some system calls, the file system path is actually in the enter event instead of the exit event. This makes it very difficult to write simple Falco rules that act on file system paths, because the field must depend on the syscall as well as the event direction.
+A variety of different syscalls take file system paths as arguments. However, there is little consistency in the fields that can access those file system paths. Depending on the syscall, the file system path might be available in `evt.rawarg.path`, `evt.rawarg.pathname`, `evt.rawarg.name`, `fd.name`, etc. And for some system calls, the file system path is in the enter event instead of the exit event. This makes writing simple Falco rules that act on file system paths challenging because the field must depend on the syscall and the event direction.
 
-To help address this inconsistency, in Falco version 0.36 we added a new set of fields that normalize file system paths across a variety of syscalls.
+To help address this inconsistency, in Falco version 0.36, we added a new set of fields that normalize file system paths across various syscalls.
 
 #### What Counts As A File System Path?
 
 Lots of existing fields also refer to file system paths. For example, `proc.exepath` contains the file system path for an executable, and there are related fields `proc.pexepath`/`proc.aexepath`. `container.mount.*` fields all contain the file system paths for file systems mounted into a container.
 
-The `fs.path.*` fields are *only* populated for syscalls that are generally related to reading, writing, or modifying some file system object and that have a file system path as an argument. The goal is to have a single set of fields that can be always relied on to refer to those paths, as compared to checking the widely varying per-event fields.
+The `fs.path.*` fields are *only* populated for syscalls generally related to reading, writing, or modifying some file system object and have a file system path as an argument. The goal is to have a single set of fields that can always be relied on to refer to those paths, compared to checking the widely varying per-event fields.
 
 ### `fs.path.*` fields
 
@@ -32,13 +32,13 @@ The following fields are available for any syscall that operates on a file syste
 * fs.path.target
 * fs.path.targetraw
 
-`fs.path.name` is for file operations that work on a path like open, unlink, rmdir, etc. For other file operations that have a source and target, like cp, symlink, link, mv, etc, there are fields `fs.path.source` and `fs.path.target`.
+`fs.path.name` is for file operations that work on a path like open, unlink, rmdir, etc. For other file operations that have a source and target, like cp, symlink, link, mv, etc., there are fields `fs.path.source` and `fs.path.target`.
 
-All of these convert relative paths to absolute paths when needed, using the thread's current working directory (cwd).
+These convert relative paths to absolute paths when needed, using the thread's current working directory (cwd).
 
 `fs.path.nameraw/fs.path.sourceraw/fs.path.targetraw` are like the above but do *not* convert relative paths to absolute paths. They always contain the original path, which may or may not be relative.
 
-The fields only work for exit events and only return a value if the syscall was successful.
+The fields only work for exit events and only return a value if the syscall succeeds.
 
 The below tables show:
 * the specific syscalls that are are supported

--- a/content/en/docs/rules/fspath.md
+++ b/content/en/docs/rules/fspath.md
@@ -1,0 +1,113 @@
+---
+title: Accessing File System Paths in Falco Rules
+description: How fs.path.* fields work
+linktitle: Accessing File System Paths
+weight: 100
+---
+
+## Introduction
+
+This section explains how the fields `fs.path.*` work and when they can be used.
+
+### Motivation
+
+A variety of different syscalls take file system paths as arguments. However, there is little consistency in the fields that can access those file system paths. Depending on the syscall, the file system path might be available in `evt.rawarg.path`, `evt.rawarg.pathname`, `evt.rawarg.name`, `fd.name`, etc. And for some system calls, the file system path is actually in the enter event instead of the exit event. This makes it very difficult to write simple Falco rules that act on file system paths, because the field must depend on the syscall as well as the event direction.
+
+To help address this inconsistency, in Falco version 0.36 we added a new set of fields that normalize file system paths across a variety of syscalls.
+
+#### What Counts As A File System Path?
+
+Lots of existing fields also refer to file system paths. For example, `proc.exepath` contains the file system path for an executable, and there are related fields `proc.pexepath`/`proc.aexepath`. `container.mount.*` fields all contain the file system paths for file systems mounted into a container.
+
+The `fs.path.*` fields are *only* populated for syscalls that are generally related to reading, writing, or modifying some file system object and that have a file system path as an argument. The goal is to have a single set of fields that can be always relied on to refer to those paths, as compared to checking the widely varying per-event fields.
+
+### `fs.path.*` fields
+
+The following fields are available for any syscall that operates on a file system path:
+
+* fs.path.name
+* fs.path.nameraw
+* fs.path.source
+* fs.path.sourceraw
+* fs.path.target
+* fs.path.targetraw
+
+`fs.path.name` is for file operations that work on a path like open, unlink, rmdir, etc. For other file operations that have a source and target, like cp, symlink, link, mv, etc, there are fields `fs.path.source` and `fs.path.target`.
+
+All of these convert relative paths to absolute paths when needed, using the thread's current working directory (cwd).
+
+`fs.path.nameraw/fs.path.sourceraw/fs.path.targetraw` are like the above but do *not* convert relative paths to absolute paths. They always contain the original path, which may or may not be relative.
+
+The fields only work for exit events and only return a value if the syscall was successful.
+
+The below tables show:
+* the specific syscalls that are are supported
+* the specific falco event identifers are supported. The reason there are multiple event identifers for the same syscall (e.g. MKDIR vs MKDIR_2) is that libs used to define new events every time we added/modified arguments to the enter or exit event. Older applications using the older version of libs will use the older event identifier for the syscall name, while newer applications will use the newer event identifier.
+* the specific event fields that are mapped to `fs.path.*` fields
+* whether the fields actually come from the enter event instead of the exit event.
+
+#### Single Argument File System Syscalls
+
+| Syscall  | Falco Libs Event Identifier   | `fs.path.name` field | From Enter Event?|
+| -------  | ------------------------------| ---------------------|------------------|
+| mkdir    | `PPME_SYSCALL_MKDIR`          | `evt.rawarg.path`    | Yes              |
+| mkdir    | `PPME_SYSCALL_MKDIR_2`        | `evt.rawarg.path`    | No               |
+| mkdirat  | `PPME_SYSCALL_MKDIRAT`        | `evt.rawarg.path`    | No               |
+| rmdir    | `PPME_SYSCALL_RMDIR`          | `evt.rawarg.path`    | Yes              |
+| rmdir    | `PPME_SYSCALL_RMDIR_2`        | `evt.rawarg.path`    | No               |
+| unlink   | `PPME_SYSCALL_UNLINK`         | `evt.rawarg.path`    | Yes              |
+| unlink   | `PPME_SYSCALL_UNLINK_2`       | `evt.rawarg.path`    | No               |
+| unlinkat | `PPME_SYSCALL_UNLINKAT`       | `evt.rawarg.name`    | Yes              |
+| unlinkat | `PPME_SYSCALL_UNLINKAT_2`     | `evt.rawarg.name`    | No               |
+| open     | `PPME_SYSCALL_OPEN`           | `evt.rawarg.name`    | No               |
+| openat   | `PPME_SYSCALL_OPENAT`         | `evt.rawarg.name`    | Yes              |
+| openat   | `PPME_SYSCALL_OPENAT_2`       | `evt.rawarg.name`    | No               |
+| openat2  | `PPME_SYSCALL_OPENAT2`        | `evt.rawarg.name`    | No               |
+| fchmod   | `PPME_SYSCALL_FCHMOD`         | `fd.name`            | No               |
+| fchmodat | `PPME_SYSCALL_FCHMODAT`       | `evt.rawarg.filename`| No               |
+| chmod    | `PPME_SYSCALL_CHMOD`          | `evt.rawarg.filename`| No               |
+| chown    | `PPME_SYSCALL_CHOWN`          | `evt.rawarg.path`    | No               |
+| lchown   | `PPME_SYSCALL_LCHOWN`         | `evt.rawarg.path`    | No               |
+| fchown   | `PPME_SYSCALL_FCHOWN`         | `fd.name`            | No               |
+| fchownat | `PPME_SYSCALL_FCHOWNAT`       | `evt.rawarg.pathname`| No               |
+| quotactl | `PPME_SYSCALL_QUOTACTL`       | `evt.rawarg.special` | No               |
+| umount   | `PPME_SYSCALL_UMOUNT`         | `evt.rawarg.name`    | No               |
+| umount   | `PPME_SYSCALL_UMOUNT_1`       | `evt.rawarg.name`    | No               |
+| umount2  | `PPME_SYSCALL_UMOUNT2`        | `evt.rawarg.name`    | No               |
+
+#### Source/Target File System Syscalls
+
+| Syscall    | Falco Libs Event Identifier   | `fs.path.source` field | `fs.path.target` field | From Enter Event? |
+| ---------- | ------------------------------| -----------------------| -----------------------| ------------------|
+| rename     | `PPME_SYSCALL_RENAME`         | `evt.rawarg.oldpath`   | `evt.arg.newpath`      | No                |
+| renameat   | `PPME_SYSCALL_RENAMEAT`       | `evt.rawarg.oldpath`   | `evt.arg.newpath`      | No                |
+| renameat2  | `PPME_SYSCALL_RENAMEAT2`      | `evt.rawarg.oldpath`   | `evt.arg.newpath`      | No                |
+| link       | `PPME_SYSCALL_LINK`           | `evt.rawarg.newpath`   | `evt.rawarg.oldpath`   | Yes               |
+| link       | `PPME_SYSCALL_LINK_2`         | `evt.arg.newpath`      | `evt.rawarg.oldpath`   | No                |
+| linkat     | `PPME_SYSCALL_LINKAT`         | `evt.rawarg.newpath`   | `evt.rawarg.oldpath`   | Yes               |
+| linkat     | `PPME_SYSCALL_LINKAT_2`       | `evt.arg.newpath`      | `evt.rawarg.oldpath`   | No                |
+| symlink    | `PPME_SYSCALL_SYMLINK`        | `evt.arg.linkpath`     | `evt.rawarg.target`    | No                |
+| symlinkat  | `PPME_SYSCALL_SYMLINKAT`      | `evt.arg.linkpath`     | `evt.rawarg.target`    | No                |
+| mount      | `PPME_SYSCALL_MOUNT`          | `evt.rawarg.dev`       | `evt.rawarg.dir`       | No                |
+
+### Example Rule Using `fs.path.*` Fields
+
+Here is an example rule that allows monitoring a wide variety of different file related operations below a set of specifed root directories:
+
+```
+- list: file_operation_paths
+  items: [/tmp/example-dir]
+
+- macro: file_operation
+  condition: (mkdir or rename or remove or open_write or create_symlink or evt.type in (link, linkat))
+
+- rule: Any File Related Operation on Path
+  desc: Detect any file operation on a single path
+  condition: (fs.path.name pmatch (file_operation_paths) or fs.path.source pmatch (file_operation_paths) or fs.target.name pmatch (file_operation_paths)) and file_operation
+  output: >
+      Some File Related Operation on Path (evt.type=%evt.type path=%fs.path.name source=%fs.path.source
+           target=%fs.target.name %user.name=%user.name proc.cmdline=%proc.cmdline proc.pcmdline=%proc.pcmdline
+	   container.id=%container.id container.name=%container.name image=%container.image.repository)
+  priority: DEBUG
+  source: syscall
+```


### PR DESCRIPTION
Add a new page that describes how fs.path.* fields work, including the specific syscalls that are supported, which fields are mapped to fs.path.name/source/target, and an example rules file that takes advantage of the fields.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area videos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

Corresponding code change PR: https://github.com/falcosecurity/libs/pull/1060