### PR TITLE
Remove 'of' typo in Environment requirement

### DIFF
--- a/content/en/docs/getting-started/try-falco/try-falcosidekick-on-kubernetes/index.md
+++ b/content/en/docs/getting-started/try-falco/try-falcosidekick-on-kubernetes/index.md
@@ -10,7 +10,7 @@ weight: 40
 
 ### 0.1 Environment
 
-This environment requires of a Kubernetes environment of at least 1 node. 
+This environment requires a Kubernetes environment of at least 1 node. 
 
 ## 1. Deploying Falcosidekick
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

 /area documentation

**What this PR does / why we need it**:
- Removes the 'of' in the [0.1 Environment](https://falco.org/docs/getting-started/try-falco/try-falcosidekick-on-kubernetes/#0-1-environment) requirement description.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1024 

**Special notes for your reviewer**:
- n/a
