### PR TITLE
update(docs): update alert forwarding page

### DIFF
--- a/content/en/docs/alerts/_index.md
+++ b/content/en/docs/alerts/_index.md
@@ -20,4 +20,4 @@ Find further information about how to configure each of those channels under [Al
 
 ## Integration with third parties
 
-Falco alerts can easily be forwarded to third-party systems like off-host SIEM, databases, or Faas. A forwarder proxy, [Falcosidekick](/docs/alerts/forwarding), was created to facilitate the integrations.
+Falco alerts can easily be forwarded to third-party systems like off-host SIEM, databases, or Faas. While many tools can natively connect to the generic alert channels that Falco provides such as files and standrd output, a forwarder proxy, [Falcosidekick](/docs/alerts/forwarding), was created to facilitate integration with more than 50 different systems.

--- a/content/en/docs/alerts/_index.md
+++ b/content/en/docs/alerts/_index.md
@@ -20,4 +20,4 @@ Find further information about how to configure each of those channels under [Al
 
 ## Integration with third parties
 
-Falco alerts can easily be forwarded to third-party systems like off-host SIEM, databases, or Faas. A forwarder proxy, [Falcosidekick](/doc/alerts/forwarding), was created to facilitate the integrations.
+Falco alerts can easily be forwarded to third-party systems like off-host SIEM, databases, or Faas. A forwarder proxy, [Falcosidekick](/docs/alerts/forwarding), was created to facilitate the integrations.

--- a/content/en/docs/alerts/forwarding.md
+++ b/content/en/docs/alerts/forwarding.md
@@ -1,6 +1,6 @@
 ---
 title: Forwarding Alerts to third parties
-description: Forward Falco Alerts to third parties
+description: Forward Falco Alerts to third parties with Falcosidekick
 linktitle: Forwarding Alerts to third parties
 weight: 30
 ---

--- a/data/en/features.yaml
+++ b/data/en/features.yaml
@@ -13,7 +13,7 @@
   - Streaming approach enables real-time response while minimizing storage costs and complexity.
   - Ready out-of-the-box with rules, which you can customize for your environment.
 - title: Integration with 50+ Systems
-  description: Forward Falco alerts to any off-host SIEM and data lake system for analysis, storage, or reaction.
+  description: "[Forward Falco alerts](/docs/alerts/) to any off-host SIEM and data lake system for analysis, storage, or reaction."
   icon: /icons/arrow-right.svg
   features: 
   - Falco alerts can easily be forwarded to more than 50+ third parties.

--- a/layouts/partials/landing/features.html
+++ b/layouts/partials/landing/features.html
@@ -7,7 +7,7 @@
       </div>
       <div class="d-flex flex-column h-100">
         <h4 class="display-4 mt-0 pb-1 feature-card__title" style="margin-left: auto; margin-right: auto;">{{ .title }}</h4>
-        <p class="flex-grow-1 mb-2 pb-1">{{ .description }}</p>
+        <p class="flex-grow-1 mb-2 pb-1">{{ .description | markdownify }}</p>
         <ul
           id="falco-features-{{ $index }}"
           class="collapse multi-collapse ml-3 pl-1 mb-2"


### PR DESCRIPTION
/kind cleanup
/area documentation

Update the homepage and forwarding page to make it clearer, plus fix a typo in the alert link.

In addition, this adds an explicit link to the box in the homepage. This way it'll be much easier for users to find the right page that shows integration capabilities.