### PR TITLE
update(supported events, supported fields): link the two pages together, fix ambiguous wording

### DIFF
--- a/content/en/docs/reference/rules/supported-events/index.md
+++ b/content/en/docs/reference/rules/supported-events/index.md
@@ -11,7 +11,7 @@ Here are the system call event types and args supported by the [kernel module an
 Note that several event types exist:
 * [Syscall events](#syscall-events) correspond to Linux system calls. Most of them have parameters, documented below, while some are detected as generic and they only offer the syscall ID.
 * [Tracepoint events](#tracepoint-events) represent internal kernel events that may be significant but don't directly translate to any syscall.
-* [Metaevents](#metaevents) are internal Falco events.
+* [Metaevents](#metaevents) are generated from supplementary data sources, for instance, during data enrichment procedures or when the need for asynchronous actions arises. This group also encompasses some of Falco's internally produced events (such as the `drop` event) that are unavailable for rules.
 * [Plugin events](#plugin-events) are internal Falco events. They act as an envelope for actual plugin event data and are not available to rules. In order to write rules that use plugins use the fields documented in the individual plugin.
 
 <!--

--- a/content/en/docs/reference/rules/supported-events/index.md
+++ b/content/en/docs/reference/rules/supported-events/index.md
@@ -11,7 +11,7 @@ Here are the system call event types and args supported by the [kernel module an
 Note that several event types exist:
 * [Syscall events](#syscall-events) correspond to Linux system calls. Most of them have parameters, documented below, while some are detected as generic and they only offer the syscall ID.
 * [Tracepoint events](#tracepoint-events) represent internal kernel events that may be significant but don't directly translate to any syscall.
-* [Metaevents](#metaevents) are internal Falco events. They are generally not available for rules.
+* [Metaevents](#metaevents) are internal Falco events.
 * [Plugin events](#plugin-events) are internal Falco events. They act as an envelope for actual plugin event data and are not available to rules. In order to write rules that use plugins use the fields documented in the individual plugin.
 
 <!--

--- a/content/en/docs/reference/rules/supported-events/index.md
+++ b/content/en/docs/reference/rules/supported-events/index.md
@@ -12,7 +12,7 @@ Note that several event types exist:
 * [Syscall events](#syscall-events) correspond to Linux system calls. Most of them have parameters, documented below, while some are detected as generic and they only offer the syscall ID.
 * [Tracepoint events](#tracepoint-events) represent internal kernel events that may be significant but don't directly translate to any syscall.
 * [Metaevents](#metaevents) are generated from supplementary data sources, for instance, during data enrichment procedures or when the need for asynchronous actions arises. This group also encompasses some of Falco's internally produced events (such as the `drop` event) that are unavailable for rules.
-* [Plugin events](#plugin-events) are internal Falco events. They act as an envelope for actual plugin event data and are not available to rules. In order to write rules that use plugins use the fields documented in the individual plugin.
+* [Plugin events](#plugin-events) act as an envelope for actual plugin event data. In order to write rules that use plugins use the fields documented in the individual plugin.
 
 <!--
 generated with:

--- a/content/en/docs/reference/rules/supported-events/supported-events.md
+++ b/content/en/docs/reference/rules/supported-events/supported-events.md
@@ -1,7 +1,7 @@
 *Schema Version*: 2.0.0
 ## Syscall events
 
-Default | Dir | Name | Params 
+Default | Dir | Name | Args 
 :-------|:----|:-----|:-----
 Yes | `>` | `open` | FSPATH **name**, FLAGS32 **flags**: *O_LARGEFILE*, *O_DIRECTORY*, *O_DIRECT*, *O_TRUNC*, *O_SYNC*, *O_NONBLOCK*, *O_EXCL*, *O_DSYNC*, *O_APPEND*, *O_CREAT*, *O_RDWR*, *O_WRONLY*, *O_RDONLY*, *O_CLOEXEC*, *O_NONE*, *O_TMPFILE*, UINT32 **mode**
 Yes | `<` | `open` | FD **fd**, FSPATH **name**, FLAGS32 **flags**: *O_LARGEFILE*, *O_DIRECTORY*, *O_DIRECT*, *O_TRUNC*, *O_SYNC*, *O_NONBLOCK*, *O_EXCL*, *O_DSYNC*, *O_APPEND*, *O_CREAT*, *O_RDWR*, *O_WRONLY*, *O_RDONLY*, *O_CLOEXEC*, *O_NONE*, *O_TMPFILE*, UINT32 **mode**, UINT32 **dev**, UINT64 **ino**
@@ -791,7 +791,7 @@ Yes | `<` | `mknodat` | SYSCALLID **ID**
 
 ## Tracepoint events
 
-Default | Dir | Name | Params 
+Default | Dir | Name | Args 
 :-------|:----|:-----|:-----
 Yes | `>` | `switch` | PID **next**, UINT64 **pgft_maj**, UINT64 **pgft_min**, UINT32 **vm_size**, UINT32 **vm_rss**, UINT32 **vm_swap**
 Yes | `>` | `procexit` | ERRNO **status**, ERRNO **ret**, SIGTYPE **sig**, UINT8 **core**
@@ -801,14 +801,14 @@ Yes | `>` | `page_fault` | UINT64 **addr**, UINT64 **ip**, FLAGS32 **error**: *P
 
 ## Plugin events
 
-Default | Dir | Name | Params 
+Default | Dir | Name | Args 
 :-------|:----|:-----|:-----
 Yes | `>` | `pluginevent` | UINT32 **plugin_id**, BYTEBUF **event_data**
 
 
 ## Metaevents
 
-Default | Dir | Name | Params 
+Default | Dir | Name | Args 
 :-------|:----|:-----|:-----
 Yes | `>` | `drop` | UINT32 **ratio**
 Yes | `<` | `drop` | UINT32 **ratio**

--- a/content/en/docs/reference/rules/supported-fields/index.md
+++ b/content/en/docs/reference/rules/supported-fields/index.md
@@ -16,7 +16,8 @@ generated with:
 falco --list=syscall --markdown  | sed -E 's/## Field Class/### Field Class/g' | awk '!/^Event Sources: syscall\w*/' | awk '/Field Class: evt/{c++;if(c==2){sub("evt","evt (for system calls)");c=0}}1'
 -->
 
-`syscall` event source fields are provided by the [Falco Drivers](/docs/event-sources/drivers/).
+`syscall` event source fields are provided by the [Falco Drivers](/docs/event-sources/drivers/). See the [supported events](supported-events) documentation to learn about all the available event types. The field `evt.arg`, `evt.args` and `evt.rawarg` is used to access arguments for each event. For example, in order to access the `target` arg of a `symlinkat` exit event you can use `evt.arg.target`.
+
 
 ```
 # System Kernel Fields

--- a/content/en/docs/reference/rules/supported-fields/index.md
+++ b/content/en/docs/reference/rules/supported-fields/index.md
@@ -8,7 +8,7 @@ weight: 60
 
 Here are the fields supported by Falco. These fields can be used in the `condition` key of a Falco rule and well as the `output` key. Any fields included in the `output` key of a rule will also be included in the alert's `output_fields` object when [`json_output`](../../alerts#json-output) is set to `true`.
 
-You can also see this set of fields via `falco --list=<source>`, with `<source>` being one of the [supported sources](../event-sources/).
+You can also see this set of fields via `falco --list=<source>`, with `<source>` being one of the [Falco event sources](/docs/event-sources/).
 
 ### System Calls (source `syscall`)
 <!-- 

--- a/content/en/docs/reference/rules/supported-fields/index.md
+++ b/content/en/docs/reference/rules/supported-fields/index.md
@@ -16,7 +16,7 @@ generated with:
 falco --list=syscall --markdown  | sed -E 's/## Field Class/### Field Class/g' | awk '!/^Event Sources: syscall\w*/' | awk '/Field Class: evt/{c++;if(c==2){sub("evt","evt (for system calls)");c=0}}1'
 -->
 
-`syscall` event source fields are provided by the [Falco Drivers](/docs/event-sources/drivers/). See the [supported events](supported-events) documentation to learn about all the available event types. The field `evt.arg`, `evt.args` and `evt.rawarg` is used to access arguments for each event. For example, in order to access the `target` arg of a `symlinkat` exit event you can use `evt.arg.target`.
+`syscall` event source fields are provided by the [Falco Drivers](/docs/event-sources/drivers/). See the [supported events](../supported-events) documentation to learn about all the available event types. The field `evt.arg`, `evt.args` and `evt.rawarg` is used to access arguments for each event. For example, in order to access the `target` arg of a `symlinkat` exit event you can use `evt.arg.target`.
 
 
 ```


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup
/area documentation

**What this PR does / why we need it**:

As written in issue 985, if you land in the supported fields page without noticing its sibling "supported events" page you might be left wondering what the events and the arguments actually are. This PR adds a link to make it clearer. In addition, I noticed that in one page the arguments were called "arguments" or "args" and in the other were called "params". Let's call them "arguments" (or args) in both pages for consistency.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #985

**Special notes for your reviewer**:
