### PR TITLE
fix(docs): changes cmd to configure apt repository

### DIFF
--- a/content/en/docs/install-operate/installation.md
+++ b/content/en/docs/install-operate/installation.md
@@ -75,9 +75,8 @@ Let's see an example of how to install the package in a Debian-like system, for 
 2. Configure the apt repository
 
     ```bash
-    sudo cat >>/etc/apt/sources.list.d/falcosecurity.list <<EOF
-    deb [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main
-    EOF
+   echo "deb [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main" | \
+    sudo tee -a /etc/apt/sources.list.d/falcosecurity.list
     ```
 
 {{% pageinfo color="info" %}}


### PR DESCRIPTION
This commit changes the command used to configure the apt repository. Instead of using `sudo cat` it uses `echo` + `sudo tee`. The current form doesn't work in Ubuntu if not run directly by root.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind translation

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1160

**Special notes for your reviewer**:
