### PR TITLE
fix(content): edit aliases to be relative

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -1,8 +1,9 @@
 ---
 title: What is Falco?
-keywords: Falco, Runtime security, kubernetes security, k8s security, Threat detection, intrusion detection, Falcosidekick
-aliases: 
-  - /about/falco/
+keywords: Falco, Runtime security, kubernetes security, k8s security, Threat detection,
+  intrusion detection, Falcosidekick
+aliases:
+- about/falco
 ---
 
 {{< blocks/content wrap="col" >}}

--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -2,7 +2,6 @@
 title: What is Falco?
 keywords: Falco, Runtime security, kubernetes security, k8s security, Threat detection, intrusion detection, Falcosidekick
 aliases: 
-  - /about/
   - /about/falco/
 ---
 

--- a/content/en/blog/falcosidekick-response-engine-part-1-kubeless.md
+++ b/content/en/blog/falcosidekick-response-engine-part-1-kubeless.md
@@ -1,10 +1,13 @@
 ---
-title: "Kubernetes Response Engine, Part 1: Falcosidekick + Kubeless"
+title: 'Kubernetes Response Engine, Part 1: Falcosidekick + Kubeless'
 date: 2021-01-15
 author: Thomas Labarussias
 slug: falcosidekick-response-engine-part-1-kubeless
-tags: ["Falcosidekick","Integration"]
-aliases: [/blog/falcosidekick-kubeless/]
+tags:
+- Falcosidekick
+- Integration
+aliases:
+- falcosidekick-kubeless
 ---
 
 > *This blog post is part of a series of articles about how to create a `Kubernetes` response engine with `Falco`, `Falcosidekick` and a `FaaS`.*

--- a/content/en/blog/falcosidekick-response-engine-part-2-openfass.md
+++ b/content/en/blog/falcosidekick-response-engine-part-2-openfass.md
@@ -1,12 +1,14 @@
 ---
-title: "Kubernetes Response Engine, Part 2: Falcosidekick + OpenFaas"
+title: 'Kubernetes Response Engine, Part 2: Falcosidekick + OpenFaas'
 date: 2021-04-11
-author: Batuhan Apaydın
+author: "Batuhan Apayd\u0131n"
 slug: falcosidekick-response-engine-part-2-openfaas
-tags: ["Falcosidekick","Integration"]
+tags:
+- Falcosidekick
+- Integration
 aliases:
-  - /blog/falcosidekick-openfaas/
-  - /blog/falcosidekick-reponse-engine-part-2-openfaas/
+- falcosidekick-openfaas
+- falcosidekick-reponse-engine-part-2-openfaas
 ---
 
 > *This blog post is part of a series of articles about how to create a `Kubernetes` response engine with `Falco`, `Falcosidekick` and a `FaaS`.*

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -3,7 +3,7 @@ title: The Falco Project
 description: Cloud Native Runtime Security
 weight: 10
 aliases:
-  - /docs/psp-support/
+- docs/psp-support
 ---
 
 ## What is Falco?

--- a/content/en/docs/event-sources/kernel/_index.md
+++ b/content/en/docs/event-sources/kernel/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Kernel Events
-description: 'Events related to the Kernel tells us most of what happens above.'
+description: Events related to the Kernel tells us most of what happens above.
 linktitle: Kernel Events
 weight: 20
 aliases:
-  - /docs/event-sources/drivers
+- drivers
 ---
 
 Falco uses different instrumentations to analyze the system workload and pass security events to {{< glossary_tooltip text="userspace" term_id="user-space" >}}. We usually refer to these instrumentations as {{< glossary_tooltip text="drivers" term_id="drivers" >}} since a driver runs in {{< glossary_tooltip text="kernelspace" term_id="kernel-space" >}}. The driver provides the **syscall event source** since the monitored events are strictly related to the {{< glossary_tooltip text="syscall" term_id="syscalls" >}} context.

--- a/content/en/docs/event-sources/kernel/dropped-events.md
+++ b/content/en/docs/event-sources/kernel/dropped-events.md
@@ -3,7 +3,8 @@ title: Actions For Dropped System Call Events
 description: Let Falco say *basta* when your system reaches its limit
 linktitle: Dropped Syscall Events
 weight: 60
-aliases: [/docs/event-sources/dropped-events/]
+aliases:
+- ../dropped-events
 ---
 ## Introduction
 

--- a/content/en/docs/event-sources/kernel/sample-events.md
+++ b/content/en/docs/event-sources/kernel/sample-events.md
@@ -1,9 +1,11 @@
 ---
 title: Generating sample events
-description: Test your Falco deployment by generating sample events under controlled circumstances
+description: Test your Falco deployment by generating sample events under controlled
+  circumstances
 linktitle: Generating sample events
 weight: 70
-aliases: [/docs/event-sources/sample-events/]
+aliases:
+- ../sample-events
 ---
 
 If you'd like to check if Falco is working properly, we have the {{< glossary_tooltip text="event-generator" term_id="event-generator" >}} tool that can perform an activity for both our {{< glossary_tooltip text="syscalls" term_id="syscalls" >}} and {{< glossary_tooltip text="k8s audit" term_id="kubernetes-audit-log" >}} related rules.

--- a/content/en/docs/event-sources/plugins/cloudtrail.md
+++ b/content/en/docs/event-sources/plugins/cloudtrail.md
@@ -3,7 +3,8 @@ title: CloudTrail Events
 description: Detect undesired actions in your AWS environment
 linktitle: CloudTrail Events
 weight: 30
-aliases: [/docs/event-sources/cloudtrail/]
+aliases:
+- ../cloudtrail
 ---
 
 The Falco [cloudtrail](https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail#readme) plugin can read [AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html) logs and emit events for each CloudTrail log entry.

--- a/content/en/docs/event-sources/plugins/kubernetes-audit.md
+++ b/content/en/docs/event-sources/plugins/kubernetes-audit.md
@@ -3,7 +3,8 @@ title: Kubernetes Audit Events
 description: Kubernetes Audit Events will give you a deeper visibility of your environment
 linktitle: Kubernetes Audit Events
 weight: 40
-aliases: [/docs/event-sources/kubernetes-audit/]
+aliases:
+- ../kubernetes-audit
 ---
 
 Falco v0.13.0 adds [Kubernetes Audit Events](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-backends) to the list of supported event sources. This is in addition to the existing support for system call events. An improved implementation of audit events was introduced in Kubernetes v1.11 and it provides a log of requests and responses to [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/). Because almost all the cluster management tasks are performed through the API server, the {{< glossary_tooltip text="audit log" term_id="kubernetes-audit-log" >}} can effectively track the changes made to your cluster.

--- a/content/en/docs/event-sources/plugins/okta.md
+++ b/content/en/docs/event-sources/plugins/okta.md
@@ -3,7 +3,8 @@ title: Okta Events
 description: Keep an eye on your activity within this famous authentication service
 linktitle: Okta Events
 weight: 50
-aliases: [/docs/event-sources/okta/]
+aliases:
+- ../okta
 ---
 
 The Falco [Okta](https://github.com/falcosecurity/plugins/blob/master/plugins/okta/README.md) plugin can read [Okta](https://www.okta.com/) logs and emit events for each Okta log entry.

--- a/content/en/docs/getting-started/additional-resources.md
+++ b/content/en/docs/getting-started/additional-resources.md
@@ -2,7 +2,8 @@
 title: Additional Resources
 description: Learn More About Falco
 slug: falco-additional
-aliases: [/falco-additional]
+aliases:
+- ../../falco-additional
 weight: 30
 ---
 

--- a/content/en/docs/getting-started/kubernetes-quickstart.md
+++ b/content/en/docs/getting-started/kubernetes-quickstart.md
@@ -2,9 +2,9 @@
 title: Try Falco on Kubernetes
 description: Learn how to deploy Falco on Kubernetes
 slug: falco-kubernetes-quickstart
-aliases: 
-  - /try-falco-on-kubernetes
-  - /docs/getting-started/try-falco/try-falcosidekick-on-kubernetes/
+aliases:
+- ../../try-falco-on-kubernetes
+- try-falco/try-falcosidekick-on-kubernetes
 weight: 25
 ---
 

--- a/content/en/docs/getting-started/linux-quickstart.md
+++ b/content/en/docs/getting-started/linux-quickstart.md
@@ -2,7 +2,8 @@
 title: Try Falco on Linux
 description: Learn how to install Falco on Linux
 slug: falco-linux-quickstart
-aliases: [/try-falco-on-ubuntu/]
+aliases:
+- ../../try-falco-on-ubuntu
 weight: 20
 ---
 

--- a/content/en/docs/install-operate/deployment.md
+++ b/content/en/docs/install-operate/deployment.md
@@ -1,7 +1,8 @@
 ---
 title: Deployment
 description: Installing Falco on a Kubernetes Cluster
-aliases: [/docs/getting-started/deployment]
+aliases:
+- ../getting-started/deployment
 weight: 45
 ---
 

--- a/content/en/docs/install-operate/download.md
+++ b/content/en/docs/install-operate/download.md
@@ -1,7 +1,9 @@
 ---
 title: Download
 description: Officially supported Falco artifacts
-aliases: [/docs/download/,/docs/getting-started/download]
+aliases:
+- ../download
+- ../getting-started/download
 weight: 20
 ---
 

--- a/content/en/docs/install-operate/installation.md
+++ b/content/en/docs/install-operate/installation.md
@@ -1,7 +1,9 @@
 ---
 title: Install
 description: Setting up Falco on a Linux system
-aliases: [/docs/installation/,/docs/getting-started/installation/]
+aliases:
+- ../installation
+- ../getting-started/installation
 weight: 30
 ---
 

--- a/content/en/docs/install-operate/running/index.md
+++ b/content/en/docs/install-operate/running/index.md
@@ -3,7 +3,7 @@ title: Running
 description: Operating and Managing Falco
 weight: 40
 aliases:
-- ../../getting-started/running
+- ../getting-started/running
 ---
 
 ## Falco packages

--- a/content/en/docs/install-operate/running/index.md
+++ b/content/en/docs/install-operate/running/index.md
@@ -2,7 +2,8 @@
 title: Running
 description: Operating and Managing Falco
 weight: 40
-aliases: [/docs/getting-started/running/]
+aliases:
+- ../../getting-started/running
 ---
 
 ## Falco packages

--- a/content/en/docs/install-operate/source.md
+++ b/content/en/docs/install-operate/source.md
@@ -1,7 +1,9 @@
 ---
 title: Build Falco from source
 description: Build Falco or its libraries yourself from the source code
-aliases: [/docs/source/,/docs/getting-started/source/]
+aliases:
+- ../source
+- ../getting-started/source
 weight: 50
 ---
 

--- a/content/en/docs/install-operate/third-party/_index.md
+++ b/content/en/docs/install-operate/third-party/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Third Party Integrations
 description: Community driven integrations built on the Falco core
-aliases: [/docs/getting-started/third-party]
+aliases:
+- ../getting-started/third-party
 weight: 70
 ---
 You can deploy Falco on local machines, cloud, managed Kubernetes clusters, or Kubernetes clusters such as K3s running on IoT & Edge computing. To test, set rules, integrate deploy Falco in a learning environment such as minikube, kind, MicroK8s, and others. You can also deploy Falco in a production environment such as CoreOS, Google Kubernetes Engine (GKE), K3s, and others.

--- a/content/en/docs/install-operate/third-party/install-tools.md
+++ b/content/en/docs/install-operate/third-party/install-tools.md
@@ -1,7 +1,9 @@
 ---
 title: Installation Tools
-description: Installation tools  that are required for integrations built on the Falco core
-aliases: [/docs/getting-started/third-party/install-tools]
+description: Installation tools  that are required for integrations built on the Falco
+  core
+aliases:
+- ../../getting-started/third-party/install-tools
 weight: 10
 ---
 

--- a/content/en/docs/install-operate/third-party/learning.md
+++ b/content/en/docs/install-operate/third-party/learning.md
@@ -1,7 +1,8 @@
 ---
 title: Learning Environment
 description: Integrations built on the Falco core in a learning environment
-aliases: [/docs/getting-started/third-party/learning]
+aliases:
+- ../../getting-started/third-party/learning
 weight: 20
 ---
 

--- a/content/en/docs/install-operate/third-party/production.md
+++ b/content/en/docs/install-operate/third-party/production.md
@@ -1,7 +1,8 @@
 ---
 title: Production Environment
 description: Integrations built on the Falco core in a production environment
-aliases: [/docs/getting-started/third-party/production]
+aliases:
+- ../../getting-started/third-party/production
 weight: 30
 ---
 

--- a/content/en/docs/install-operate/upgrade.md
+++ b/content/en/docs/install-operate/upgrade.md
@@ -1,7 +1,8 @@
 ---
 title: Upgrade
 description: Upgrading Falco on a Linux system
-aliases: [/docs/getting-started/upgrade]
+aliases:
+- ../getting-started/upgrade
 weight: 30
 ---
 

--- a/content/en/docs/outputs/_index.md
+++ b/content/en/docs/outputs/_index.md
@@ -2,7 +2,8 @@
 title: Falco Outputs
 description: Work with Falco Outputs and send Falco Alerts in your desired platform
 linktitle: Falco Outputs
-aliases: [/docs/alerts/]
+aliases:
+- alerts
 weight: 40
 ---
 

--- a/content/en/docs/outputs/channels.md
+++ b/content/en/docs/outputs/channels.md
@@ -2,7 +2,8 @@
 title: Output Channels
 description: Supported output channels for Falco Alerts
 linktitle: Output Channels
-aliases: [/docs/alerts/channels/]
+aliases:
+- ../alerts/channels
 weight: 10
 ---
 

--- a/content/en/docs/outputs/formatting.md
+++ b/content/en/docs/outputs/formatting.md
@@ -2,7 +2,8 @@
 title: Output Formatting
 description: Format Falco Alerts for Containers and Kubernetes
 linktitle: Output Formatting
-aliases: [/docs/alerts/formatting/]
+aliases:
+- ../alerts/formatting
 weight: 20
 ---
 

--- a/content/en/docs/outputs/forwarding.md
+++ b/content/en/docs/outputs/forwarding.md
@@ -3,7 +3,8 @@ title: Forwarding Alerts
 description: Forward Falco Alerts to third parties with Falcosidekick
 linktitle: Forwarding Alerts
 weight: 30
-aliases: [/docs/alerts/forwarding/]
+aliases:
+- ../alerts/forwarding
 ---
 
 Falco alerts can easily be forwarded to third-party systems. Their JSON format allows them to be easily consumed for storage, analysis and reaction. 

--- a/content/en/docs/plugins/developers-guide/_index.md
+++ b/content/en/docs/plugins/developers-guide/_index.md
@@ -3,7 +3,8 @@ title: Falco Plugins Developers Guide
 linktitle: Developers Guide
 description: Start writing your own Falco plugins
 weight: 10
-aliases: [/docs/plugins/developers_guide/]
+aliases:
+- developers_guide
 ---
 
 ## Introduction

--- a/content/en/docs/reference/changelog/index.md
+++ b/content/en/docs/reference/changelog/index.md
@@ -2,7 +2,8 @@
 title: Changelog
 linktitle: Changelog
 description: List of changes throughout Falco versions
-aliases: ["/docs/changelog/"]
+aliases:
+- ../../changelog
 weight: 200
 notoc: true
 no_edit: true

--- a/content/en/docs/reference/changelog/index.md
+++ b/content/en/docs/reference/changelog/index.md
@@ -3,7 +3,7 @@ title: Changelog
 linktitle: Changelog
 description: List of changes throughout Falco versions
 aliases:
-- ../../changelog
+- ../changelog
 weight: 200
 notoc: true
 no_edit: true

--- a/content/en/docs/reference/daemon/cli-arguments/index.md
+++ b/content/en/docs/reference/daemon/cli-arguments/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- ../../../getting-started/running/arguments
+- ../../getting-started/running/arguments
 title: Falco Daemon Arguments
 linktitle: Falco Arguments
 description: List of CLI arguments allowed by Falco

--- a/content/en/docs/reference/daemon/cli-arguments/index.md
+++ b/content/en/docs/reference/daemon/cli-arguments/index.md
@@ -1,13 +1,17 @@
 ---
-aliases: ["/docs/getting-started/running/arguments"]
+aliases:
+- ../../../getting-started/running/arguments
 title: Falco Daemon Arguments
 linktitle: Falco Arguments
 description: List of CLI arguments allowed by Falco
 weight: 20
 no_edit: true
 notoc: true
-categories: ["Installation", "Deployment"]
-tags: ["Falco Daemon"]
+categories:
+- Installation
+- Deployment
+tags:
+- Falco Daemon
 ---
 
 This page lists all arguments you can pass to Falco in your command line:

--- a/content/en/docs/reference/daemon/config-options/index.md
+++ b/content/en/docs/reference/daemon/config-options/index.md
@@ -6,7 +6,7 @@ weight: 40
 notoc: true
 no_edit: true
 aliases:
-- ../../../configuration
+- ../../configuration
 categories:
 - Installation
 - Deployment

--- a/content/en/docs/reference/daemon/config-options/index.md
+++ b/content/en/docs/reference/daemon/config-options/index.md
@@ -5,9 +5,16 @@ description: Configuration for the Falco daemon
 weight: 40
 notoc: true
 no_edit: true
-aliases: ["/docs/configuration/"]
-categories: ["Installation", "Deployment", "Configuration"]
-tags: ["Falco Daemon", "falco.yaml", "rules files"]
+aliases:
+- ../../../configuration
+categories:
+- Installation
+- Deployment
+- Configuration
+tags:
+- Falco Daemon
+- falco.yaml
+- rules files
 ---
 
 Falco's configuration file is a YAML file containing a collection of `key: value` or `key: [value list]` pairs.

--- a/content/en/docs/reference/plugins/go-sdk-walkthrough.md
+++ b/content/en/docs/reference/plugins/go-sdk-walkthrough.md
@@ -3,7 +3,8 @@ title: Falco Plugins Go SDK Walkthrough
 linktitle: Go SDK Walkthrough
 description: High-level documentation of the Go SDK
 weight: 30
-aliases: [/docs/plugins/go-sdk-walkthrough]
+aliases:
+- ../../plugins/go-sdk-walkthrough
 ---
 
 ## Introduction

--- a/content/en/docs/reference/plugins/plugin-api-reference.md
+++ b/content/en/docs/reference/plugins/plugin-api-reference.md
@@ -3,7 +3,8 @@ title: Falco Plugins API Reference
 linktitle: API Reference
 description: Learn how the Plugins API works
 weight: 20
-aliases: [/docs/plugins/plugin-api-reference]
+aliases:
+- ../../plugins/plugin-api-reference
 ---
 
 ## Introduction

--- a/content/en/docs/reference/rules/default-macros/index.md
+++ b/content/en/docs/reference/rules/default-macros/index.md
@@ -2,7 +2,8 @@
 title: Default Macros
 linktitle: Default Macros
 description: Use the default macros to simplify Falco Rules
-aliases: ["/docs/rules/default-macros"]
+aliases:
+- ../../../rules/default-macros
 weight: 20
 ---
 

--- a/content/en/docs/reference/rules/default-macros/index.md
+++ b/content/en/docs/reference/rules/default-macros/index.md
@@ -3,7 +3,7 @@ title: Default Macros
 linktitle: Default Macros
 description: Use the default macros to simplify Falco Rules
 aliases:
-- ../../../rules/default-macros
+- ../../rules/default-macros
 weight: 20
 ---
 

--- a/content/en/docs/reference/rules/examples/index.md
+++ b/content/en/docs/reference/rules/examples/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- ../../../examples
+- ../../examples
 title: Rules Examples
 description: Several examples of Falco Rules
 weight: 80

--- a/content/en/docs/reference/rules/examples/index.md
+++ b/content/en/docs/reference/rules/examples/index.md
@@ -1,5 +1,6 @@
 ---
-aliases: ["/docs/examples/"]
+aliases:
+- ../../../examples
 title: Rules Examples
 description: Several examples of Falco Rules
 weight: 80

--- a/content/en/docs/reference/rules/supported-events/index.md
+++ b/content/en/docs/reference/rules/supported-events/index.md
@@ -3,7 +3,7 @@ title: Supported Events
 linktitle: Supported Events
 description: Find out which events Falco supports
 aliases:
-- ../../../rules/supported-events
+- ../../rules/supported-events
 weight: 40
 ---
 

--- a/content/en/docs/reference/rules/supported-events/index.md
+++ b/content/en/docs/reference/rules/supported-events/index.md
@@ -2,7 +2,8 @@
 title: Supported Events
 linktitle: Supported Events
 description: Find out which events Falco supports
-aliases: ["/docs/rules/supported-events"]
+aliases:
+- ../../../rules/supported-events
 weight: 40
 ---
 

--- a/content/en/docs/reference/rules/supported-fields/index.md
+++ b/content/en/docs/reference/rules/supported-fields/index.md
@@ -1,5 +1,6 @@
 ---
-aliases: ["/docs/rules/supported-fields"]
+aliases:
+- ../../../rules/supported-fields
 title: Supported Fields for Conditions and Outputs
 description: Events fields that you can use in conditions and outputs of Falco Rules
 linktitle: Fields for Conditions and Outputs

--- a/content/en/docs/reference/rules/supported-fields/index.md
+++ b/content/en/docs/reference/rules/supported-fields/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- ../../../rules/supported-fields
+- ../../rules/supported-fields
 title: Supported Fields for Conditions and Outputs
 description: Events fields that you can use in conditions and outputs of Falco Rules
 linktitle: Fields for Conditions and Outputs

--- a/content/en/training/_index.md
+++ b/content/en/training/_index.md
@@ -2,5 +2,6 @@
 title: Falco Training
 description: Learn about Falco with free training
 weight: 1
-aliases: [/labs/]
+aliases:
+- labs
 ---


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area documentation

**What this PR does / why we need it**:

Still drawing inspiration from @vjjmiras 's wisdom here: https://github.com/falcosecurity/falco-website/pull/1155 . According to the [documentation](https://gohugo.io/content-management/urls/#aliases):

> An alias without a leading slash is relative to the current directory"

In English, navigating to `/about/falco` should redirect to `/about/`

In no circumstances `/docs/about/` should ever send you to `/ja/docs/about/`. This PR allows to better test this theory.

If this works properly, we can proceed to add the mounts shown in https://github.com/falcosecurity/falco-website/pull/1155 and so we can fill the missing multilang pages with the English ones.

**Which issue(s) this PR fixes**:

Part of https://github.com/falcosecurity/falco-website/issues/1175

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
