### PR TITLE
update(learning/minikube): add instructions to use modern-bpf probe

### DIFF
--- a/content/en/docs/install-operate/third-party/learning.md
+++ b/content/en/docs/install-operate/third-party/learning.md
@@ -52,6 +52,10 @@ In order to install Falco with the `kernel module` or the `bpf probe`:
         ```shell
         helm install falco --set driver.kind=ebpf --set tty=true falcosecurity/falco
         ```
+    3. With modern-bpf probe(recommended):
+        ```shell
+        helm install falco --set driver.kind=modern-bpf --set tty=true falcosecurity/falco
+        ```
 
     The output is similar to:
 
@@ -248,7 +252,7 @@ Here we run Falco in `minikube` cluster with multiple sources: `syscall` and `k8
     # Default value: kernel module.
     driver:
       enabled: true
-      kind: module
+      kind: modern-bpf
 
     # Enable the collectors used to enrich the events with metadata.
     # Check the values.yaml file for fine-grained options.
@@ -344,7 +348,7 @@ Here we run Falco in `minikube` cluster with multiple sources: `syscall` and `k8
    The command will follow the log stream of the Falco pod by printing the logs as soon as Falco emits them. And make sure that the following lines are present:
    ```bash
    Mon Oct 24 15:24:06 2022: Opening capture with plugin 'k8saudit'
-   Mon Oct 24 15:24:06 2022: Opening capture with Kernel module
+   Mon Oct 24 15:24:06 2022: Opening 'syscall' source with modern BPF probe
    ```
    It means that Falco is running with the configured sources.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

> /kind content

> /kind translation

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

**What this PR does / why we need it**:

This PR adds instructions to use `modern-bpf` probe in the Minikube tutorial. Since Minikube ships with recent kernels, the `modern-bps probe` should be used. No need for precompiled` kernel module` or `bpf probe.` 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
