### PR TITLE
update(docs): fixed command for running privileged ebpf falco docker.

### DIFF
--- a/content/en/docs/install-operate/running/index.md
+++ b/content/en/docs/install-operate/running/index.md
@@ -208,13 +208,14 @@ Alternatively, you can use the eBPF probe driver:
 docker pull falcosecurity/falco:latest
 docker run --rm -i -t \
     --privileged \
+    -e FALCO_DRIVER_LOADER_OPTIONS="ebpf" \
     -v /var/run/docker.sock:/host/var/run/docker.sock \
     -v /proc:/host/proc:ro \
     -v /boot:/host/boot:ro \
     -v /lib/modules:/host/lib/modules:ro \
     -v /usr:/host/usr:ro \
     -v /etc:/host/etc:ro \
-    falcosecurity/falco:latest -o engine.kind=ebpf
+    falcosecurity/falco:latest falco -o engine.kind=ebpf
 
 # Please remember to add '-v /sys/kernel/debug:/sys/kernel/debug:ro \' to the above docker command
 # if you are running a kernel version < 4.14


### PR DESCRIPTION
The existing privileged docker command for running ebpf incorrectly tries to load the kmod, while running falco in ebpf mode.  By adding an environment variable we force the container to load the ebpf probe.  The command was also missing the `falco` cli.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

 /kind bug

**Any specific area of the project related to this PR?**

/area documentation


**What this PR does / why we need it**:

It fixes the docker command for loading the ebpf version of falco.  The current command errors in two ways:
1. Since it doesn't have `falco` in it, docker incorrectly thinks the executable is `-o`
2. The docker container loads the kmod probe, but falco is loaded in `ebpf` mode.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
