### PR TITLE
Update falco-m1.md, use modern-bpf for helm

### DIFF
--- a/content/en/blog/falco-m1.md
+++ b/content/en/blog/falco-m1.md
@@ -278,7 +278,7 @@ Then, we need to add the `falcosecurity` helm repository and install the `falcos
 ```shell
 $ helm repo add falcosecurity https://falcosecurity.github.io/charts
 $ helm repo update
-$ helm install falco falcosecurity/falco --namespace falco --create-namespace --set driver.kind=ebpf
+$ helm install falco falcosecurity/falco --namespace falco --create-namespace --set driver.kind=modern-bpf
 ```
 
 This will trigger the deployment of Falco on your Kubernetes cluster. The `falco-driver-loader` init container will perform all the steps required to build the eBPF probe (hint: the kernel headers are already included in the VM) as you can see with the following snippet:


### PR DESCRIPTION
Using `driver.kind=modern-bpf` instead of `driver.kind=bpf` resolves the issue like this:

```Error: BPF probe is compiled for 5.15.0-100-generic-64k, but running version is 5.15.0-100-generic```

**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area blog

**What this PR does / why we need it**:

Correction in the blog text, which allows to avoid the error of mismatch between the kernel version for which the probe was compiled and the kernel version that's currently running on your system.

**Which issue(s) this PR fixes**:

n/a

Fixes #

**Special notes for your reviewer**:
see https://kubernetes.slack.com/archives/CMWH3EH32/p1701096740993579 
