### PR TITLE
fix: update sysdig training links

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -206,9 +206,9 @@ courses = [
 [[training.contribution]]
 src = "sysdig.png"
 alt = "Falco 101 course by Sysdig"
-url = "https://learn.sysdig.com/path/falco"
+url = "https://sysdig.com/opensource/falco/"
 courses = [
-            ["Falco 101", "https://learn.sysdig.com/path/falco/falco-101", "All you need to learn to get started with Falco"], 
-            ["Falco Plugins", "https://learn.sysdig.com/path/falco/falco-plugins", "Extending Falco to secure your cloud services"], 
-            ["Detecting a Cryptomining Malware attack with Falco and Prometheus", "https://learn.sysdig.com/path/falco/detecting-a-crytomining-malware-attack-with-falco-and-prometheus", "Learn how to detect Cryptominers with Falco and Prometheus"]
+            ["Falco 101", "https://play.instruqt.com/sysdig/invite/yxodyyqszehc", "All you need to learn to get started with Falco"],
+            ["Falco Plugins", "https://play.instruqt.com/sysdig/invite/8ssx1yay5yi7", "Extending Falco to secure your cloud services"],
+            ["Detecting a Cryptomining Malware attack with Falco and Prometheus", "https://play.instruqt.com/sysdig/invite/qgym9z4uzqug", "Learn how to detect Cryptominers with Falco and Prometheus"]
         ]

--- a/data/training/offerings/detect-cryptomining.yaml
+++ b/data/training/offerings/detect-cryptomining.yaml
@@ -1,7 +1,7 @@
 ---
 name: Detecting a Cryptomining Malware attack with Falco and Prometheus
 type: course 
-link: https://learn.sysdig.com/path/falco/detecting-a-crytomining-malware-attack-with-falco-and-prometheus
+link: https://play.instruqt.com/sysdig/invite/qgym9z4uzqug
 description: Learn how to detect Cryptominers with Falco and Prometheus
 thumbnail: detecting-cryptomining.svg
 duration: 2 hr 00 min

--- a/data/training/offerings/falco-101.yaml
+++ b/data/training/offerings/falco-101.yaml
@@ -1,7 +1,7 @@
 ---
 name: Falco 101
 type: course
-link: https://learn.sysdig.com/path/falco/falco-101
+link: https://play.instruqt.com/sysdig/invite/yxodyyqszehc
 description: All you need to learn to get started with Falco
 thumbnail: falco-101.svg
 duration: 5 hr 41 min

--- a/data/training/offerings/falco-plugins.yaml
+++ b/data/training/offerings/falco-plugins.yaml
@@ -1,7 +1,7 @@
 ---
 name: Falco Plugins
 type: course
-link: https://learn.sysdig.com/path/falco/falco-plugins
+link: https://play.instruqt.com/sysdig/invite/8ssx1yay5yi7
 description: Extending Falco to secure your cloud services
 thumbnail: falco-plugins.svg
 duration: 1 hr 27 min


### PR DESCRIPTION
**What type of PR is this?**

This updates the links for the Sysdig training content. The old links were removed since we switched to a different training platform.

/kind content
/area documentation
/area community
