### PR TITLE
fix(docs): fix command to retrieve Falco pid for hot reloading

### DIFF
--- a/content/en/docs/setup/tarball.md
+++ b/content/en/docs/setup/tarball.md
@@ -105,7 +105,7 @@ By default, with the `watch_config_files` configuration option enabled, Falco au
 If this option is disabled, you can manually reload the configuration by sending a `SIGHUP` signal to the Falco process. To do this, use the following command:
 
 ```shell
-kill -1 $(cat /var/run/falco.pid)
+kill -1 $(pidof falco)
 ```
 
 ## Upgrade


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

**What this PR does / why we need it**:


This PR fixes the command used in the documentation to retrieve the Falco pid for hot reloading.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
