### PR TITLE
update(docs): rephrase and update rule override doc

### DIFF
--- a/content/en/docs/rules/overriding.md
+++ b/content/en/docs/rules/overriding.md
@@ -190,6 +190,28 @@ Use the new `override` section to enable the rule instead.
     enabled: replace
 ```
 
+## Precedence of logical operators when appending
+
+Remember that when appending rules and macros, the content of the referring rule or macro is simply added to the condition of the referred one.
+This can result in unintended results if the original rule/macro has potentially ambiguous logical operators.
+
+Here's an example:
+
+```yaml
+- rule: my_rule
+  desc: ...
+  condition: evt.type=open and proc.name=apache
+  output: ...
+
+- rule: my_rule
+  append: true
+  condition: or proc.name=nginx
+```
+
+Should `proc.name=nginx` be interpreted as relative to the `and proc.name=apache`, that is to allow either apache/nginx to open files, or relative to the `evt.type=open`, that is to allow apache to open files or to allow nginx to do anything?
+
+In cases like this, be sure to scope the logical operators of the original condition with parentheses when possible, or avoid appending conditions when not possible.
+
 ## Appending to existing rules using `append` key (deprecated)
 
 {{% alert color="warning" %}}
@@ -306,26 +328,3 @@ The rule `program_accesses_file` would trigger when `ls`/`cat` either used `open
 It is also possible to append exceptions to rules.\
 [Here](/docs/rules/exceptions/#appending-exception-values) you can find further information.
 {{% /alert %}}
-
-## Precedence of logical operators when appending
-
-Remember that when appending rules and macros, the content of the referring rule or macro is simply added to the condition of the referred one. 
-This can result in unintended results if the original rule/macro has potentially ambiguous logical operators. 
-
-Here's an example:
-
-```yaml
-- rule: my_rule
-  desc: ...
-  condition: evt.type=open and proc.name=apache
-  output: ...
-
-- rule: my_rule
-  append: true
-  condition: or proc.name=nginx
-```
-
-Should `proc.name=nginx` be interpreted as relative to the `and proc.name=apache`, that is to allow either apache/nginx to open files, or relative to the `evt.type=open`, that is to allow apache to open files or to allow nginx to do anything?
-
-In cases like this, be sure to scope the logical operators of the original condition with parentheses when possible, or avoid appending conditions when not possible.
-

--- a/content/en/docs/rules/overriding.md
+++ b/content/en/docs/rules/overriding.md
@@ -190,10 +190,10 @@ Use the new `override` section to enable the rule instead.
     enabled: replace
 ```
 
-## Appending to existing rules using `append:true` (deprecated)
+## Appending to existing rules using `append` key (deprecated)
 
 {{% alert color="warning" %}}
-This method has been deprecated and will be removed in Falco 1.0.0 
+The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.  
 {{% /alert %}}
 
 If you use multiple Falco {{< glossary_tooltip text="rules files" term_id="rules-file" >}}, you might want to append new items to an existing lists, macros or rules. To do that, define an item with the same name as an existing item and add an `append: true` attribute to the YAML object. 
@@ -207,15 +207,23 @@ Note that when appending to lists, rules or macros, the order of the rule config
 
 This can be configured with multiple `-r` parameters in the right order, directly inside the Falco configuration file (`falco.yaml`) via `rules_files` or if you use the official Helm chart, via the `falco.rules_files` value.
 
-## Redefining Rules
+## Redefining existing rules using `append` key (deprecated)
 
-On the contrary, if `append` is set to `false` (default value), the whole object will be redefined. This can be used to empty a list, [apply user-specific settings to a macro](/docs/reference/rules/macros-override/) or even change a rule completely.
+{{% alert color="warning" %}}
+The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.
+{{% /alert %}}
+
+If `append` is set to `false` (default value), the whole object will be redefined. This can be used to empty a list, [apply user-specific settings to a macro](/docs/reference/rules/macros-override/) or even change a rule completely.
 
 Take into account that when redefining a rule, it will entirely replace the previous rule, so if the new object defines fewer fields than required, Falco could return an error. 
 
 The only exceptions to this are the `enabled` field, that when defined as a single accompanying field, it simply enables or disables a previously-defined rule. And obviously, the `append` field, that when set to `true` for either macros or rules, it just appends the condition/exceptions field.
 
-## Examples of Appending to Rules
+## Examples of appending using `append` key (deprecated)
+
+{{% alert color="warning" %}}
+The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.
+{{% /alert %}}
 
 In all the examples below, it's assumed one is running Falco via `falco -r /etc/falco/falco_rules.yaml -r /etc/falco/falco_rules.local.yaml`, or has the default entries for `rules_files` in falco.yaml, which has `/etc/falco/falco.yaml` first and `/etc/falco/falco_rules.local.yaml` second.
 

--- a/content/en/docs/rules/overriding.md
+++ b/content/en/docs/rules/overriding.md
@@ -214,9 +214,9 @@ In cases like this, be sure to scope the logical operators of the original condi
 
 ## Appending to existing rules using `append` key (deprecated)
 
-{{% alert color="warning" %}}
-The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.  
-{{% /alert %}}
+{{% pageinfo color=warning %}}
+The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.
+{{% /pageinfo %}}
 
 If you use multiple Falco {{< glossary_tooltip text="rules files" term_id="rules-file" >}}, you might want to append new items to an existing lists, macros or rules. To do that, define an item with the same name as an existing item and add an `append: true` attribute to the YAML object. 
 
@@ -231,9 +231,9 @@ This can be configured with multiple `-r` parameters in the right order, directl
 
 ## Redefining existing rules using `append` key (deprecated)
 
-{{% alert color="warning" %}}
+{{% pageinfo color=warning %}}
 The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.
-{{% /alert %}}
+{{% /pageinfo %}}
 
 If `append` is set to `false` (default value), the whole object will be redefined. This can be used to empty a list, [apply user-specific settings to a macro](/docs/reference/rules/macros-override/) or even change a rule completely.
 
@@ -243,9 +243,9 @@ The only exceptions to this are the `enabled` field, that when defined as a sing
 
 ## Examples of appending using `append` key (deprecated)
 
-{{% alert color="warning" %}}
+{{% pageinfo color=warning %}}
 The `append` key has been deprecated and will be removed in Falco 1.0.0. Use the [`override` section](/docs/rules/overriding/#overview) instead.
-{{% /alert %}}
+{{% /pageinfo %}}
 
 In all the examples below, it's assumed one is running Falco via `falco -r /etc/falco/falco_rules.yaml -r /etc/falco/falco_rules.local.yaml`, or has the default entries for `rules_files` in falco.yaml, which has `/etc/falco/falco.yaml` first and `/etc/falco/falco_rules.local.yaml` second.
 

--- a/content/en/docs/rules/overriding.md
+++ b/content/en/docs/rules/overriding.md
@@ -24,7 +24,7 @@ To facilitate modifying existing lists, macros and rules Falco provides an `over
 
 `append` allows you to add additional values to a list, macro, or rule key
 
-`replace` allows you to replace the value of an list, macro or macro key
+`replace` allows you to replace the value of a list, macro or macro key
 
 {{% alert color="warning" %}}
 `append` and `replace` cannot be used together. Trying to apply both will result in an error. 
@@ -41,7 +41,7 @@ The keys that can be overridden vary by rules component and action being taken:
 
 The following examples illustrate how you can use the override section to modify existing lists, macros, and rules. 
 
-In all of the examples below, it's assumed one is running Falco via `falco -r /etc/falco/falco_rules.yaml -r /etc/falco/falco_rules.local.yaml`, or has the default entries for `rules_files` in falco.yaml, which has `/etc/falco/falco.yaml` first and `/etc/falco/falco_rules.local.yaml` second.
+In all the examples below, it's assumed one is running Falco via `falco -r /etc/falco/falco_rules.yaml -r /etc/falco/falco_rules.local.yaml`, or has the default entries for `rules_files` in falco.yaml, which has `/etc/falco/falco.yaml` first and `/etc/falco/falco_rules.local.yaml` second.
 
 ### Append an item to a list
 
@@ -217,7 +217,7 @@ The only exceptions to this are the `enabled` field, that when defined as a sing
 
 ## Examples of Appending to Rules
 
-In all of the examples below, it's assumed one is running Falco via `falco -r /etc/falco/falco_rules.yaml -r /etc/falco/falco_rules.local.yaml`, or has the default entries for `rules_files` in falco.yaml, which has `/etc/falco/falco.yaml` first and `/etc/falco/falco_rules.local.yaml` second.
+In all the examples below, it's assumed one is running Falco via `falco -r /etc/falco/falco_rules.yaml -r /etc/falco/falco_rules.local.yaml`, or has the default entries for `rules_files` in falco.yaml, which has `/etc/falco/falco.yaml` first and `/etc/falco/falco_rules.local.yaml` second.
 
 ### Appending to Lists
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

**What this PR does / why we need it**:

This PR rephrases the rule overriding documentation by putting more emphasis on `append` key deprecation. Moving in this direction, the operator precedence section has been moved before sections documenting the deprecated feature.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
