### PR TITLE
Revert "fix(docs): remove references to broken -o option"

### DIFF
--- a/content/en/blog/falco-0-39-0/index.md
+++ b/content/en/blog/falco-0-39-0/index.md
@@ -64,6 +64,13 @@ append_output:
 ```
 In this example, any rule with the syscall source will have the string on `CPU %evt.cpu` appended to the end of the default output line. Additionally, extra fields such as `home_directory` and `evt.hostname` will be visible in the JSON output under the `output_fields`key but won’t appear in the regular text output. Notably, environment variables are also supported.
 
+This option is also available on the command line using the `-o flag`. For example:
+
+```bash
+falco ... -o 'append_output[]={"match": {"source": "syscall"}, "extra_fields": ["evt.hostname"], "extra_output": "on CPU %evt.cpu"}'
+```
+The introduction of `append_output` offers Falco users a flexible way to enrich event outputs, providing deeper visibility and customization tailored to their monitoring needs.
+
 ### Dynamic Driver Selection in Falco with Helm: Simplifying Multi-Node Deployments
 Deploying across diverse Kubernetes environments just got easier! When using the official Falco Helm chart and setting `driver.kind=auto`, the driver loader now intelligently handles the heavy lifting for you.
 

--- a/content/en/docs/outputs/formatting.md
+++ b/content/en/docs/outputs/formatting.md
@@ -41,17 +41,11 @@ The `match` section can be used to specify optional conditions:
 
 If multiple conditions are specified all need to be present in order to match. If none are specified or `match` is not present output is appended to all rules.
 
-<!--
-
-This -o variant is not available in Falco 0.39.0 due to a cxxopts config issue
-
 This option can also be specified on the command line via `-o` such as:
 
 ```sh
 falco ... -o 'append_output[]={"match": {"source": "syscall"}, "extra_fields": ["evt.hostname"], "extra_output": "on CPU %evt.cpu"}'
 ```
-
--->
 
 ## Adding an override to a specific rule
 


### PR DESCRIPTION
This reverts commit d19bd1d6f41a66d03b4e7c9b50a16b5ede27cde1.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area blog

/area documentation

**What this PR does / why we need it**:

The `-o` command line usage works as advertised in Falco 0.39.1

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
