### PR TITLE
update(docs): replace deprecated cri options and update falco cli arguments page

### DIFF
--- a/content/en/docs/setup/enviroments.md
+++ b/content/en/docs/setup/enviroments.md
@@ -19,7 +19,7 @@ To use Falco on GKE, you need to [deploy](/docs/setup/kubernetes/) using one of 
 If you are using K3s with containerd, you should set the CRI settings because the socket path is different from the default setting configured in Falco.
 
 - If you install Falco on the host machine:
-  - Append the parameter `--cri /run/k3s/containerd/containerd.sock` when starting the Falco binary.
+  - Append the parameter `-o container_engines.cri.sockets[]=/run/k3s/containerd/containerd.sock` when starting the Falco binary.
 - If you install Falco inside K3s with Helm:
   - Append the options below when installing with Helm:
 

--- a/content/en/docs/troubleshooting/missing-fields.md
+++ b/content/en/docs/troubleshooting/missing-fields.md
@@ -23,8 +23,8 @@ Furthermore, sometimes Linux may not operate exactly as expected. One concrete e
 Check the basics:
 
 - Is the container runtime socket correctly mounted? For Kubernetes, mount with the `HOST_ROOT` prefix: `/host/run/k3s/containerd/containerd.sock`. See [deploy-kubernetes](https://github.com/falcosecurity/deploy-kubernetes/tree/main/kubernetes) example template.
-- Is a custom path specified for the container runtime socket in Kubernetes? If yes, use the `--cri` command line option when running Falco. The default paths include: `/run/containerd/containerd.sock`, `/run/k3s/containerd/containerd.sock`, `/run/crio/crio.sock`.
-- To expedite lookups, attempt to disable asynchronous CRI API calls by using the `--disable-cri-async` command line option when running Falco.
+- Is a custom path specified for the container runtime socket in Kubernetes? If yes, use the `-o container_engines.cri.sockets[]=<socket_path>` command line option when running Falco. The default paths include: `/run/containerd/containerd.sock`, `/run/k3s/containerd/containerd.sock`, `/run/crio/crio.sock`.
+- To expedite lookups, attempt to disable asynchronous CRI API calls by using the `-o container_engines.cri.disable_async=true` command line option when running Falco.
 - If you run the upstream Falco rules containing the `%container.info` placeholder output field, run Falco with the `-pc` or `-pk` command line option to automatically include and resolve crucial container and Kubernetes-related output fields. For additional details, consult the [Outputs Formatting](/doc/outputs/formatting/) Guide, and consider adding more [Supported Output Fields](/docs/reference/rules/supported-fields/#field-class-container).
 - Falco monitors both host and container processes. If the `container.id` is set to `host`, it indicates that the process is running on the host, and therefore, no container image is associated with it.
 
@@ -60,7 +60,7 @@ Here is an example metrics log snippet highlighting the fields crucial for this 
 
 To complicate matters, some processes in Kubernetes run in the pod sandbox container, which has no container image in the API responses. In such cases, the `container.id` is the same as the `k8s.pod.sandbox_id`. If the container image is consistently missing throughout the lifetime of the container, it's likely a process in a pod sandbox container in the majority of the cases. However, sandbox containers likely constitute less than 1% of the distinct containers in your overall Falco logs. Note that this comparison will be fully supported by Falco 0.38 and is a work in progress. 
 
-Additionally, the improvement of the overall efficiency of the container engine, especially for the `--disable-cri-async` option, is also a work in progress. A more performant implementation is expected to be available by Falco 0.38. This improvement aims to address missing images observed by adopters and resolve most cases, leaving only some edge cases of race conditions where the lookup hasn't happened yet.
+Additionally, the improvement of the overall efficiency of the container engine, especially for the `-o container_engines.cri.disable_async=true` option, is also a work in progress. A more performant implementation is expected to be available by Falco 0.38. This improvement aims to address missing images observed by adopters and resolve most cases, leaving only some edge cases of race conditions where the lookup hasn't happened yet.
 
 ## Missing User Names
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

**What this PR does / why we need it**:
This PR replaces the references to `--cri` and `--disable-cri-async` cri-related options in the documentation. Moreover, it updates the Falco CLI arguments page. The deprecated options are left into the CLI arguments page to be consistent with the later published Falco 0.39.1 version.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1378

**Special notes for your reviewer**:
