### PR TITLE
fix: falcoctl installation command (for linux amd64 system)

### DIFF
--- a/content/en/blog/falcoctl-install-manage-rules-plugins/index.md
+++ b/content/en/blog/falcoctl-install-manage-rules-plugins/index.md
@@ -47,7 +47,7 @@ The following steps explain the basic concepts used to install `falcoctl` locall
 For a Linux amd64 system:
 ```shell
 LATEST=$(curl -sI https://github.com/falcosecurity/falcoctl/releases/latest | awk '/location: /{gsub("\r","",$2);split($2,v,"/");print substr(v[8],2)}')
-curl --fail -LS "https://github.com/falcosecurity/falcoctl/releases/download/v${LATEST}/falcoctl_${LATEST}_linux_amd64.tar.gz" | tar -xz
+curl --fail -LS "https://github.com/falcosecurity/falcoctl/releases/download/v${LATEST}/falcoctl_${LATEST}_linux_amd64.tar.gz" | tar -xz falcoctl
 sudo install -o root -g root -m 0755 falcoctl /usr/local/bin/falcoctl
 ```
 


### PR DESCRIPTION

**What type of PR is this?**

> /kind content

**Any specific area of the project related to this PR?**

> /area blog


**What this PR does / why we need it**:

The actual command extract the falcoctl binary but also LICENSE and README files. So if you already have a README and a LICENSE file in the current folder, they are replaced with the falcoctl ones ;) (yes it happened to me ^^).
So I fixed the command to extract only `falcoctl` binary.
