### PR TITLE
Fix the rule example defined in write_binary_dir.md

### DIFF
--- a/content/en/docs/reference/rules/examples/write_binary_dir.md
+++ b/content/en/docs/reference/rules/examples/write_binary_dir.md
@@ -16,7 +16,7 @@
 
 - rule: write_binary_dir
   desc: an attempt to write to any file below a set of binary directories
-  condition: evt.dir = < and open_write and not proc.name in (package_mgmt_binaries) and bin_dir
+  condition: evt.dir = < and open_write and not package_mgmt_binaries and bin_dir
   output: "File below a known binary directory opened for writing (user=%user.name command=%proc.cmdline file=%fd.name)"
   priority: WARNING
 ```


### PR DESCRIPTION
The 'write_binary_dir' rule's condition refers to 'package_mgmt_binaries' as it would be a list of strings when it is actually a macro. The solution is to refer to it as a macro, which fixes the warning and also enables the intended behavior.

**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area documentation
/area rules

**What this PR does / why we need it**:

The original example produces a warning and does not behave as expected: binaries defined by 'package_mgmt_binaries' are not excluded.

**Which issue(s) this PR fixes**:

Fixes #1464 

**Special notes for your reviewer**:
