### PR TITLE
Fix broken Golang SDK link

### DIFF
--- a/content/en/docs/developer-guide/grpc/_index.md
+++ b/content/en/docs/developer-guide/grpc/_index.md
@@ -14,4 +14,4 @@ The current APIs are:
 - [schema definition](/docs/developer-guide/grpc/outputs): get or subscribe to Falco output events.
 - [schema definition](/docs/developer-guide/grpc/version): retrieve the Falco version.
 
-In order to interact with these APIs, the The Falco Project provides a [Golang SDK](/docs/grpc/client-go).
+In order to interact with these APIs, the The Falco Project provides a [Golang SDK](/docs/developer-guide/grpc/client-go/).


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:
While reading this documentation, I noticed a broken link.
This updates the link to match the links in the sidebar.

