### PR TITLE
docs: add that regex performs full match

### DIFF
--- a/content/en/docs/concepts/rules/conditions.md
+++ b/content/en/docs/concepts/rules/conditions.md
@@ -45,7 +45,7 @@ Operators | Description
 `in` | Evaluates whether the first set is completely contained in the second set. Example: `(b,c,d) in (a,b,c)` is `FALSE` because `d` is not found in `(a,b,c)`.
 `intersects` | Evaluates whether the first set has at least one element in common with the second set. Example: `(b,c,d) intersects (a,b,c)` is `TRUE` because both sets contain `b` and `c`.
 `pmatch` | Compares a file path against a set of file or directory prefixes. Example: `fd.name pmatch (/tmp/hello)` evaluates to true for `/tmp/hello`, `/tmp/hello/world` but not `/tmp/hello_world`. More details in the [below section](#pmatch-operator).
-`regex` | Checks whether a string field matches a [Google RE2](https://github.com/google/re2/wiki/Syntax)-compatible regular expression. Note that `regex` can be considerably slower than simpler string operations. Example: `fd.name regex '[a-z]*/proc/[0-9]+/cmdline'`.
+`regex` | Checks whether a string field matches a [Google RE2](https://github.com/google/re2/wiki/Syntax)-compatible regular expression. Note that `regex` can be considerably slower than simpler string operations. The `regex` operator performs full match only, not partial match. Example: `fd.name regex '[a-z]*/proc/[0-9]+/cmdline'`.
 `startswith`, `bstartswith` | Checks if a string starts with a given prefix. The `bstartswith` variant allows byte matching against a raw string of bytes, taking a hexadecimal string as input. For example: `evt.buffer bstartswith 012AB3CC`.
 
 #### `pmatch` operator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

<!--
> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface
-->

/kind content

<!-- > /kind event -->

**Any specific area of the project related to this PR?**

<!--
> Uncomment one (or more) `/area <>` lines:

> /area blog
-->

/area documentation

<!-- > /area community -->

**What this PR does / why we need it**:

The `regex` operator supports only full matches, but this behavior is not documented on the website.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/falcosecurity/falco/issues/3627

<!-- **Special notes for your reviewer**: -->
