### PR TITLE
fix(ui): Resolve hidden submenus on tablet portrait viewports

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -5,7 +5,7 @@
       <span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="font-weight-bold">{{ .Site.Title }}</span>
     </a>
   </div>
-	<div class="td-navbar-nav-scroll ml-md-auto w-100" id="main_navbar">
+	<div class="ml-md-auto w-100" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0 justify-content-center">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
/kind user-interface

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area documentation
> /area community

**What this PR does / why we need it**:
This Pull Request resolves an issue where navigation submenus on the Falco website (`falco.org`) were hidden or obscured when viewed on tablet devices in portrait orientation (specifically screen widths between 768px and 991px).

**Which issue(s) this PR fixes**:

Fixes #1487

**Special notes for your reviewer**:

**Tablet Portrait View (Before):**
<img width="320" alt="navbar-tablet-before" src="https://github.com/user-attachments/assets/da8d66d7-6fef-40e8-9353-35720ee7c174" />

**Tablet Portrait View (After):**
<img width="320" alt="navbar-tablet-after" src="https://github.com/user-attachments/assets/bf1ed962-9f8e-48fe-ae99-d6dc3ad8690a" />


**Desktop Screenshot (Unaffected):**
<img width="320" alt="navbar-desktop" src="https://github.com/user-attachments/assets/f6641e64-b867-41bb-b573-5d043dcdd9fa" />

