### PR TITLE
FIX issue 1509 - Broken link to falco-with-multiple-sources anchor section

### DIFF
--- a/content/en/docs/concepts/event-sources/plugins/kubernetes-audit.md
+++ b/content/en/docs/concepts/event-sources/plugins/kubernetes-audit.md
@@ -223,7 +223,7 @@ The output string is used to print essential information about the audit event, 
 
 To enable Kubernetes audit logs, you need to change the arguments to the `kube-apiserver` process to add `--audit-policy-file` and `--audit-webhook-config-file` arguments and provide files that implement an audit policy/webhook configuration. 
 
-It is beyond the scope of Falco documentation to give a detailed description of how to do this, but [this step-by-step guide](/docs/getting-started/third-party/learning/#falco-with-multiple-sources) will show you how to configure `kubernetes audit logs` on `minikube` and deploy Falco. Managed Kubernetes providers will usually provide a mechanism to configure the audit system.
+It is beyond the scope of Falco documentation to give a detailed description of how to do this, but [this step-by-step guide](/docs/getting-started/learning-environments/#falco-with-multiple-sources) will show you how to configure `kubernetes audit logs` on `minikube` and deploy Falco. Managed Kubernetes providers will usually provide a mechanism to configure the audit system.
 
 {{% alert color="warning" %}}
 Dynamic Audit Webhooks were [removed](https://github.com/kubernetes/kubernetes/pull/91502) from Kubernetes. However, static audit configuration continues to work.


### PR DESCRIPTION
Commit description: FIX broken link fixed by replacing "/docs/getting-started/third-party/learning" by "/docs/getting-started/learning-environments" in URI path

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

It fix a broken link issue in website.

**Which issue(s) this PR fixes**:
https://github.com/falcosecurity/falco-website/issues/1509
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
