### PR TITLE
fix: correct event-sources documentation links to prevent redirects

### DIFF
--- a/content/en/docs/concepts/event-sources/_index.md
+++ b/content/en/docs/concepts/event-sources/_index.md
@@ -11,7 +11,7 @@ aliases:
 
 Falco evaluates streams of events against security rules to detect abnormal behavior. Events are consumed through various event sources, which define the origin, nature, and format of the streamed events.
 
-Falco natively supports the `syscall` event source, which is enabled by default, consuming events from the Linux Kernel via drivers. The [plugin system](/docs/event-sources/plugins/) allows Falco to extend its capabilities with new event sources.
+Falco natively supports the `syscall` event source, which is enabled by default, consuming events from the Linux Kernel via drivers. The [plugin system](/docs/concepts/event-sources/plugins/) allows Falco to extend its capabilities with new event sources.
 
 ### How It Works
 

--- a/content/en/docs/concepts/event-sources/kernel/_index.md
+++ b/content/en/docs/concepts/event-sources/kernel/_index.md
@@ -21,8 +21,8 @@ There are several supported drivers:
 
 |             | Kernel module | Legacy eBPF probe (deprecated) | Modern eBPF probe                                                    |
 | ----------- |---------------|--------------------------------| -------------------------------------------------------------------- |
-| **x86_64**  | >= 3.10       | >= 4.14                        | [Minimal set of features](/docs/event-sources/kernel/#requirements) |
-| **aarch64** | >= 3.10       | >= 4.17                        | [Minimal set of features](/docs/event-sources/kernel/#requirements) |
+| **x86_64**  | >= 3.10       | >= 4.14                        | [Minimal set of features](/docs/concepts/event-sources/kernel/#requirements) |
+| **aarch64** | >= 3.10       | >= 4.17                        | [Minimal set of features](/docs/concepts/event-sources/kernel/#requirements) |
 
 ## Kernel module
 

--- a/content/en/docs/concepts/event-sources/plugins/kubernetes-audit.md
+++ b/content/en/docs/concepts/event-sources/plugins/kubernetes-audit.md
@@ -47,7 +47,7 @@ Now, the plugin-based implementation is compliant to the new semantics supported
 
 * The `/healthz` endpoint of Falco cannot bind to the same port of the K8S Audit Log endpoint (e.g. `/k8s-audit`), due to the fact that they are now managed by two different webservers (one in Falco, one in the plugin).
 
-* In Falco versions 0.32.x ([Falco v0.32.0](/blog/falco-0-32-0/), [v0.32.1](/blog/falco-0-32-1/), and [ v0.32.2](/blog/falco-0-32-2/)), Falco didn't allow the use of Syscalls and K8S Audit event sources on the same instance. Starting from [version 0.33.0](/blog/falco-0-33-0/), Falco introduced the capability of [consuming events from multiple event sources simultaneously within the same Falco instance](/docs/event-sources/#configuring-event-sources).
+* In Falco versions 0.32.x ([Falco v0.32.0](/blog/falco-0-32-0/), [v0.32.1](/blog/falco-0-32-1/), and [ v0.32.2](/blog/falco-0-32-2/)), Falco didn't allow the use of Syscalls and K8S Audit event sources on the same instance. Starting from [version 0.33.0](/blog/falco-0-33-0/), Falco introduced the capability of [consuming events from multiple event sources simultaneously within the same Falco instance](/docs/concepts/event-sources/#configuring-event-sources).
 
 ## Kubernetes Audit Rules
 

--- a/content/en/docs/reference/glossary/drivers.md
+++ b/content/en/docs/reference/glossary/drivers.md
@@ -2,7 +2,7 @@
 title: Drivers
 id: drivers
 date: 2023-07-17
-full_link: /docs/event-sources/kernel/
+full_link: /docs/concepts/event-sources/kernel/
 short_description: >
   The global term for the software that sends events from the kernel.
 aka:

--- a/content/en/docs/reference/glossary/ebpf.md
+++ b/content/en/docs/reference/glossary/ebpf.md
@@ -2,7 +2,7 @@
 title: eBPF
 id: ebpf
 date: 2023-07-17
-full_link: /docs/event-sources/kernel/#classic-ebpf-probe
+full_link: /docs/concepts/event-sources/kernel/#legacy-ebpf-probe
 short_description: >
   eBPF is a technology to collect metrics and events from the Kernel in a secure way.
 tags:

--- a/content/en/docs/reference/rules/supported-events/index.md
+++ b/content/en/docs/reference/rules/supported-events/index.md
@@ -7,7 +7,7 @@ aliases:
 weight: 40
 ---
 
-Here are the system call event types and args supported by the [kernel module and eBPF probes](/docs/event-sources/drivers) via `libscap` included in the Falco libs. Note that, for performance reasons, by default Falco will only consider a subset of them indicated in the table below with "yes". However, it's possible to make Falco consider all events by using the `-A` command line switch.
+Here are the system call event types and args supported by the [kernel module and eBPF probes](/docs/concepts/event-sources/kernel/) via `libscap` included in the Falco libs. Note that, for performance reasons, by default Falco will only consider a subset of them indicated in the table below with "yes". However, it's possible to make Falco consider all events by using the `-A` command line switch.
 
 Note that several event types exist:
 * [Syscall events](#syscall-events) correspond to Linux system calls. Most of them have parameters, documented below, while some are detected as generic and they only offer the syscall ID.

--- a/content/en/docs/reference/rules/supported-fields/index.md
+++ b/content/en/docs/reference/rules/supported-fields/index.md
@@ -9,11 +9,11 @@ weight: 60
 
 Here are the fields supported by Falco. These fields can be used in the `condition` key of a Falco rule and well as the `output` key. Any fields included in the `output` key of a rule will also be included in the alert's `output_fields` object when `json_output` is set to `true`.
 
-You can also see this set of fields via `falco --list=<source>`, with `<source>` being one of the [Falco event sources](/docs/event-sources/).
+You can also see this set of fields via `falco --list=<source>`, with `<source>` being one of the [Falco event sources](/docs/concepts/event-sources/).
 
 ### System Calls (source `syscall`)
 
-`syscall` event source fields are provided by the [Falco Drivers](/docs/event-sources/drivers/). See the [supported events](/docs/reference/rules/supported-events/) documentation to learn about all the available event types. The field `evt.arg`, `evt.args` and `evt.rawarg` is used to access arguments for each event. For example, in order to access the `target` arg of a `symlinkat` exit event you can use `evt.arg.target`.
+`syscall` event source fields are provided by the [Falco Drivers](/docs/concepts/event-sources/kernel/). See the [supported events](/docs/reference/rules/supported-events/) documentation to learn about all the available event types. The field `evt.arg`, `evt.args` and `evt.rawarg` is used to access arguments for each event. For example, in order to access the `target` arg of a `symlinkat` exit event you can use `evt.arg.target`.
 
 
 ```

--- a/content/en/docs/setup/download.md
+++ b/content/en/docs/setup/download.md
@@ -63,13 +63,13 @@ The Falco packages and container images come with a built-in ruleset file (inclu
 
 {{% pageinfo color="primary" %}}
 
-When using Falco for [Kernel Events](/docs/event-sources/kernel/) (i.e., with the `syscall` data source enabled), the Falco binary relies on having a {{< glossary_tooltip text="driver" term_id="drivers" >}} available on the host system.
+When using Falco for [Kernel Events](/docs/concepts/event-sources/kernel/) (i.e., with the `syscall` data source enabled), the Falco binary relies on having a {{< glossary_tooltip text="driver" term_id="drivers" >}} available on the host system.
 
 Starting from Falco 0.38.0, the default driver is the {{< glossary_tooltip text="Modern eBPF" term_id="modern-ebpf-probe" >}} driver, which is included in the Falco binary and built using the [CO-RE "Compile Once - Run Everywhere"](https://en.wikipedia.org/wiki/EBPF#eBPF_CO-RE_(Compile_Once_-_Run_Everywhere)) technology. If your system satisfies the modern eBPF driver requirements, no further action is needed. Otherwise, you need to use the {{< glossary_tooltip text="Kernel Module" term_id="kernel-module-driver" >}}, which provides wider compatibility.
 
 In brief, you don't need to install a driver if you are either:
- - using the [modern eBPF driver](/docs/event-sources/kernel/#modern-ebpf-probe) (default option) 
- - or if you are using only [plugin data sources](/docs/event-sources/plugins/).
+ - using the [modern eBPF driver](/docs/concepts/event-sources/kernel/#modern-ebpf-probe) (default option) 
+ - or if you are using only [plugin data sources](/docs/concepts/event-sources/plugins/).
 
 {{% /pageinfo %}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

**What this PR does / why we need it**:
This PR updates several internal links in the documentation that were still pointing to paths under the old `/docs/event-sources/` directory.

Since that directory has now been moved to [/docs/concepts/event-sources/](cci:7://file:///Users/saikumar.peddireddy/sai/Repo/forked-falco-web/content/en/docs/concepts/event-sources:0:0-0:0), updating the source markdown links directly reduces load times because the user no longer has to undergo an HTML alias redirect from Hugo to load the new content. This slightly improves UX, SEO, and helps reduce warning outputs in standard automated link-checking workflows like `htmltest`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:
Only Markdown documentation files containing outdated internal link segments were modified in this PR directly.
