### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
+# Keep in sync with NODE_VERSION in netlify.toml build.environment
 FROM node:24.13.0-bookworm
 
+# Keep in sync with NPM_VERSION in netlify.toml build.environment
 RUN npm install -g npm@11.8.0
 
 RUN corepack enable && corepack prepare yarn@stable --activate

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:24.13.0-bookworm
+
+RUN npm install -g npm@11.8.0
+
+RUN corepack enable && corepack prepare yarn@stable --activate

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Falco Website",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/hugo:1": {
+      "version": "0.154.5",
+      "extended": true
+    },
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "forwardPorts": [1313],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "budparr.language-hugo-vscode",
+        "davidanson.vscode-markdownlint"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
     "dockerfile": "Dockerfile"
   },
   "features": {
+    // Keep in sync with HUGO_VERSION in netlify.toml build.environment
     "ghcr.io/devcontainers/features/hugo:1": {
       "version": "0.154.5",
       "extended": true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ To build this website you need:
 git clone git@github.com:falcosecurity/falco-website.git
 ```
 
+#### Dev Containers
+
+If you are using Visual Studio Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), the development container is ready to use. Open the repository in VS Code and select **Reopen in Container** when prompted. All required tools (Hugo, Node.js, Yarn) will be automatically set up for you.
+
 #### Run hugo server
 
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

**What this PR does / why we need it**:

Add a devcontainer configuration to enable a consistent, reproducible development environment for the Falco website project. The toolchain versions in the Dockerfile and devcontainer.json are aligned with those defined in `netlify.toml` (`NODE_VERSION=24.13.0`, `NPM_VERSION=11.8.0`, `HUGO_VERSION=0.154.5`) to ensure parity between the local development environment and the production build environment. This includes:

- A `Dockerfile` based on Node.js 24.13.0 (Bookworm) with npm 11.8.0 and Yarn (via corepack)
- A `devcontainer.json` that installs Hugo Extended v0.154.5 and Git as dev container features, forwards port 1313 for the Hugo dev server, and pre-installs VS Code extensions for Hugo language support and Markdown linting

This allows contributors to quickly spin up a fully configured development environment using GitHub Codespaces or VS Code Dev Containers without manual setup.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A


**Special notes for your reviewer**:

N/A