### PR TITLE
docs: cross-link Visibility section to Overriding Rules

### DIFF
--- a/content/en/docs/concepts/rules/basic-elements.md
+++ b/content/en/docs/concepts/rules/basic-elements.md
@@ -270,3 +270,5 @@ In other words, visibility is defined in cascade and is quite important:
 - A macro can only reference macros defined before it.
 - A macro can reference any list.
 - A rule can reference any macro.
+
+The same load-order principle applies across multiple rules files. See [Overriding Rules](/docs/concepts/rules/overriding/#overview) for details on how the order of rules files affects appending and overriding existing lists, macros, and rules.


### PR DESCRIPTION
The Visibility section in basic-elements explains within-file load order for lists/macros/rules. Add a pointer to Overriding Rules so readers also discover the file-level load-order rules that govern append/override.

Refs: https://github.com/falcosecurity/falco-website/issues/1341

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind user-interface

/kind content

> /kind event

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area blog

/area documentation

> /area community

> /area automation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/falcosecurity/falco-website/issues/1341

**Special notes for your reviewer**:
