### PR TITLE
docs(rules): add VS Code extension and Falco Playground to IDE support page

### DIFF
--- a/content/en/docs/concepts/rules/ide-support.md
+++ b/content/en/docs/concepts/rules/ide-support.md
@@ -9,8 +9,24 @@ aliases:
 
 For some Integrated Development Environment (IDE) Editors, there is support for falco rules files that allow for on-the-fly syntax checking and validation of rules content.
 
+#### Visual Studio Code
+
+The [Falco Rules](https://marketplace.visualstudio.com/items?itemName=c2ndev.falco-rules) extension for VS Code provides syntax highlighting, hover documentation, and real-time validation of Falco rules files. It is powered by [falco-lsp](https://github.com/falcosecurity/falco-lsp), the official Falco Language Server Protocol implementation.
+
+Features include:
+
+- Syntax highlighting for `.yaml` Falco rules files
+- Hover documentation for fields, macros, and rule elements
+- Real-time diagnostics backed by the Falco rule engine
+
+Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=c2ndev.falco-rules) or search for **"Falco Rules"** in the VS Code Extensions panel.
+
 #### Emacs
 
 For emacs, there is a [Flycheck](https://www.flycheck.org) checker called [flycheck-falco-rules](https://github.com/falcosecurity/flycheck-falco-rules):
 
 ![](https://github.com/falcosecurity/flycheck-falco-rules/raw/main/flycheck-falco-rules-example.png)
+
+#### Falco Playground (browser)
+
+The [Falco Playground](https://falcosecurity.github.io/falco-playground/) is a browser-based editor with live rule validation powered by the official Falco WebAssembly build. No local installation is required — paste or write rules and get immediate feedback from the Falco engine.


### PR DESCRIPTION
## Summary

- Adds a Visual Studio Code section documenting the [Falco Rules](https://marketplace.visualstudio.com/items?itemName=c2ndev.falco-rules) extension powered by [falco-lsp](https://github.com/falcosecurity/falco-lsp)
- Adds a Falco Playground (browser) section for the WebAssembly-based online editor
- Closes #1544

## Changes

The `ide-support.md` page previously only listed the Emacs Flycheck integration. This PR adds:

1. **Visual Studio Code** — documents the `c2ndev.falco-rules` marketplace extension with its features (syntax highlighting, hover docs, real-time diagnostics) and links to both the marketplace page and the `falco-lsp` repository.
2. **Falco Playground (browser)** — documents the browser-based editor at `falcosecurity.github.io/falco-playground/` as a zero-install option for quick rule validation.

## Test plan

- [ ] Verify Markdown renders correctly in Hugo
- [ ] Check all links resolve (VS Code Marketplace, falco-lsp GitHub, Falco Playground)