### PR TITLE
Fix typos and a broken link in plugin and rules docs

### DIFF
--- a/content/en/docs/concepts/rules/fspath.md
+++ b/content/en/docs/concepts/rules/fspath.md
@@ -43,7 +43,7 @@ These convert relative paths to absolute paths when needed, using the thread's c
 The fields only work for exit events and only return a value if the syscall succeeds.
 
 The below tables show:
-* the specific syscalls that are are supported
+* the specific syscalls that are supported
 * the specific falco event identifiers are supported. The reason there are multiple event identifiers for the same syscall (e.g. MKDIR vs MKDIR_2) is that libs used to define new events every time we added/modified arguments to the event. Older applications using the older version of libs will use the older event identifier for the syscall name, while newer applications will use the newer event identifier.
 * the specific event fields that are mapped to `fs.path.*` fields
 
@@ -85,7 +85,7 @@ The below tables show:
 
 ### Example Rule Using `fs.path.*` Fields
 
-Here is an example rule that allows monitoring a wide variety of different file related operations below a set of specifed root directories:
+Here is an example rule that allows monitoring a wide variety of different file related operations below a set of specified root directories:
 
 ```
 - list: file_operation_paths

--- a/content/en/docs/reference/plugins/go-sdk-walkthrough.md
+++ b/content/en/docs/reference/plugins/go-sdk-walkthrough.md
@@ -77,7 +77,7 @@ type InitSchema interface {
 }
 ```
 
-Plugins with field extraction capability can optionally implement the `sdk.Destroyer` interface. In that case, `Destroy()` will be called when the plugin gets destroyed and can be used to release any allocated resource. they can also also optionally implement the `sdk.InitSchema` interface. In that case, `InitSchema()` will be used to to return a schema describing the data expected to be passed as a configuration during the plugin initialization. This follows the semantics documented for [`get_init_schema`](/docs/reference/plugins/plugin-api-reference/#get-init-schema). Currently, the schema must follow the [JSON Schema specific](https://json-schema.org/), which in Go can also be easily auto-generated with external packages (e.g. [alecthomas/jsonschema](https:/github.com/alecthomas/jsonschema)).
+Plugins with field extraction capability can optionally implement the `sdk.Destroyer` interface. In that case, `Destroy()` will be called when the plugin gets destroyed and can be used to release any allocated resource. They can also optionally implement the `sdk.InitSchema` interface. In that case, `InitSchema()` will be used to return a schema describing the data expected to be passed as a configuration during the plugin initialization. This follows the semantics documented for [`get_init_schema`](/docs/reference/plugins/plugin-api-reference/#get-init-schema). Currently, the schema must follow the [JSON Schema specific](https://json-schema.org/), which in Go can also be easily auto-generated with external packages (e.g. [alecthomas/jsonschema](https://github.com/alecthomas/jsonschema)).
 
 ### Defining a Plugin with Event Sourcing Capability
 


### PR DESCRIPTION
Small, verifiable documentation fixes:

**`docs/reference/plugins/go-sdk-walkthrough.md`**
- Broken link: `https:/github.com/alecthomas/jsonschema` (single slash) -> `https://github.com/alecthomas/jsonschema`
- `also also optionally` -> `also optionally`
- `used to to return` -> `used to return`
- Capitalize sentence start: `resource. they` -> `resource. They`

**`docs/concepts/rules/fspath.md`**
- `syscalls that are are supported` -> `are supported`
- `specifed root directories` -> `specified root directories`

All in hand-authored docs; no meaning changes.