### PR TITLE
fix(docs): fix typo in overriding.md rule example

### DIFF
--- a/content/en/docs/concepts/rules/overriding.md
+++ b/content/en/docs/concepts/rules/overriding.md
@@ -127,7 +127,7 @@ The rule `program_accesses_file` would trigger when `ls`/`cat` either used `open
 
 ```yaml
 - rule: program_accesses_file
-  desc: Yrack whenever a set of programs opens a file
+  desc: Track whenever a set of programs opens a file
   condition: evt.type=open and proc.name in (cat, ls) 
   output: A tracked program opened a file | user=%user.name command=%proc.cmdline file=%fd.name
   priority: INFO


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

Fixes a typo in the `program_accesses_file` rule example in `overriding.md` (`Yrack` → `Track`).

**Which issue(s) this PR fixes**:

N/A